### PR TITLE
candlepin: remove nssdb dependency

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -79,8 +79,6 @@ class certs::candlepin (
   $client_key = "${pki_dir}/private/${java_client_cert_name}.key"
 
   if $deploy {
-    include ::certs::ssltools::nssdb
-
     certs::keypair { 'tomcat':
       key_pair  => $tomcat_cert_name,
       key_file  => $tomcat_key,
@@ -107,12 +105,6 @@ class certs::candlepin (
       key_pair  => $java_client_cert_name,
       key_file  => $client_key,
       cert_file => $client_cert,
-    } ~>
-    certs::ssltools::certutil { 'amqp-client':
-      nss_db_dir  => $nss_db_dir,
-      client_cert => $client_cert,
-      refreshonly => true,
-      subscribe   => Exec['create-nss-db'],
     } ~>
     file { $amqp_store_dir:
       ensure => directory,

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -21,10 +21,6 @@ describe 'certs' do
         ensure => present,
       }
 
-      group { 'qpidd':
-        ensure => present,
-      }
-
       ['/usr/share/tomcat/conf', '/etc/candlepin/certs/amqp'].each |$dir| {
         exec { "mkdir -p ${dir}":
           creates => $dir,


### PR DESCRIPTION
I don't see any reasoning for this code being there. Basically, it adds candlepin's `java-client` cert (the cert candlepin uses to connect to qpidd) to the qpidd truststore.
Candlepin doesn't need this to boot up. And it doesn't need this to connect to qpidd. We don't do anything similar elsewhere. I mean, isn't the idea of a PKI to not whitelist individual certificates but trust the CA?

Anyways, this removes another dependency. Goes along with https://github.com/Katello/puppet-katello/pull/215 to remove the qpidd dependency.