### PR TITLE
Fix debian OS determination

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -8,7 +8,6 @@ PREFIX=<%= scope['certs::katello::deployment_url'] %>
 CFG=/etc/rhsm/rhsm.conf
 CFG_BACKUP=$CFG.kat-backup
 CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors
-OSFAMILY=$(sed -n -e "s/ID\s*=\s*\(.*\)/\1/p" /etc/os-release)
 
 # exit on non-RHEL systems or when rhsm.conf is not found
 test -f $CFG || exit
@@ -38,7 +37,7 @@ then
     --server.port="$PORT" \
     --rhsm.repo_ca_cert="%(ca_cert_dir)s$KATELLO_SERVER_CA_CERT" \
     --rhsm.baseurl="$BASEURL"
-elif [ "${OSFAMILY}" = "debian" ]
+elif [ -r "/etc/os-release" ] && [ "$(sed -n -e "s/^ID\s*=\s*\(.*\)/\1/p" /etc/os-release)" = "debian" ]
 then
   # Debian setup
   BASEURL=https://$KATELLO_SERVER/pulp/deb


### PR DESCRIPTION
```
Running Transaction                             
  Installing : katello-ca-consumer-centos7-dev2.strangeways.example.com-1.0-1.noarch                                                                                                           1/1 
sed: can't read /etc/os-release: No such file or directory                                       
warning: %post(katello-ca-consumer-centos7-dev2.strangeways.example.com-1.0-1.noarch) scriptlet failed, exit status 2                                                                              
Non-fatal POSTIN scriptlet failure in rpm package katello-ca-consumer-centos7-dev2.strangeways.example.com-1.0-1.noarch                                                                              Verifying  : katello-ca-consumer-centos7-dev2.strangeways.example.com-1.0-1.noarch                                                                                                           1/1 

Installed:                                      
  katello-ca-consumer-centos7-dev2.strangeways.example.com.noarch 0:1.0-1 
```

Hmm, what happened?

```
[root@rhel6 vagrant]# katello-rhsm-consumer
sed: can't read /etc/os-release: No such file or directory
```

Ah! We don't have os-release in EL6.. I think I've fixed it. I also corrected the regex by adding a '^' in front of 'ID' since it was matching too much.



