### PR TITLE
Fixes #22884 - Check RHSM version for hostname-override

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -106,13 +106,19 @@ fi
   service goferd status >/dev/null && \
   service goferd restart >/dev/null 2&>1
 
+[ -f /usr/lib/systemd/system/goferd.service ] && \
 [ -f /bin/systemctl ] && \
   systemctl try-restart goferd >/dev/null 2>&1
 
-
-FQDN=`hostname -f`
-if [ $? == "0" ] && [ "$FQDN" != "localhost" ] && [ -d /etc/rhsm/facts/ ]; then
-  echo "{\"network.hostname-override\":\"$FQDN\"}" > /etc/rhsm/facts/katello.facts
+# EL5 systems and subscription-manager versions before 1.18.1-1 don't have the network.fqdn fact.
+# For these cases, we have to update the "hostname-override" fact
+if (test -f /etc/redhat-release && grep -q -i "Red Hat Enterprise Linux Server release 5" /etc/redhat-release) || \
+   (test -f /etc/centos-release && grep -q -i "CentOS Linux release 5" /etc/centos-release) || \
+   test ${RHSM_VERSION[0]:-0} -lt 1 -o ${RHSM_VERSION[1]:-0} -lt 18 -o \( ${RHSM_VERSION[1]:-0} -eq 18 -a ${RHSM_VERSION[2]:-0} -lt 2 \); then
+  FQDN=`hostname -f`
+  if [ $? == "0" ] && [ "$FQDN" != "localhost" ] && [ -d /etc/rhsm/facts/ ]; then
+    echo "{\"network.hostname-override\":\"$FQDN\"}" > /etc/rhsm/facts/katello.facts
+  fi
 fi
 
 exit 0


### PR DESCRIPTION
The adding of a subscription-manager fact is failing on
stock SLES12 installs as 'hostname -f' doesn't work "out of
the box":

`hostname: Name or service not known`

This is due to /etc/hosts not having the FQDN associated with
127.0.0.1

Its an easy fix, but for automated provisioning/scripting we
want to be sure the bootstrap rpm script will run without
issues.

The subscription manager hostname-override fact isn't
needed for subscription manager versions past 1.18.1-1,
so we can skip this block of code for later versions.

This commit checks the subscription manager version before
adding the hostname-override fact. This is something we
should do anyways and it avoids the error for SLES.
SLES will use subscription-manager-1.20.5-7.1.x86_64 or
later, so this block of code isn't even needed.