### PR TITLE
Clean up $nss_db_dir handling

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -23,7 +23,6 @@ class certs::candlepin (
   $ca_key_password_file   = $::certs::ca_key_password_file,
   $user                   = $::certs::user,
   $group                  = $::certs::group,
-  $nss_db_dir             = $::certs::nss_db_dir,
 ) inherits certs {
 
   Exec {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,6 @@ class certs::params {
   $ca_expiration = '36500' # 100 years
 
   $keystore_password_file = 'keystore_password-file'
-  $nss_db_dir = "${pki_dir}/nssdb"
 
   $user = 'root'
   $group = 'root'

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -13,7 +13,6 @@ class certs::qpid (
   $default_ca           = $::certs::default_ca,
   $ca_key_password_file = $::certs::ca_key_password_file,
   $pki_dir              = $::certs::pki_dir,
-  $nss_db_dir           = $::certs::nss_db_dir,
   $ca_cert              = $::certs::ca_cert,
   $qpidd_group          = $::certs::qpidd_group,
 ) inherits certs {
@@ -41,6 +40,7 @@ class certs::qpid (
 
   if $deploy {
     include ::certs::ssltools::nssdb
+    $nss_db_dir = $::certs::ssltools::nssdb::nss_db_dir
     $nss_db_password_file = $::certs::ssltools::nssdb::nss_db_password_file
 
     $client_cert            = "${pki_dir}/certs/${qpid_cert_name}.crt"


### PR DESCRIPTION
Both in candlepin.pp and in params.pp they are unused so we can remove them. For qpid it shouldn't be a class parameter because one could override it in the nssdb class and things would break.

Technically we should remove it from init.pp too and only define it in nssdb.pp as a class parameter default, but puppet-katello uses it on the main class so we keep it in for now.