### PR TITLE
Refs #15963 - katello-installer --help typos

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,12 +32,12 @@
 #                         configuration
 #
 # $regenerate::           Force regeneration of the certificates (excluding
-#                         ca certificates)
+#                         CA certificates)
 #
-# $regenerate_ca::        Force regeneration of the ca certificate
+# $regenerate_ca::        Force regeneration of the CA certificate
 #
 # $deploy::               Deploy the certs on the configured system. False means
-#                         we want apply it on a different system
+#                         we want to apply it to a different system
 #
 # $ca_common_name::       Common name for the generated CA certificate
 #


### PR DESCRIPTION
Hi,

This is one of a series of patches to address typos in `katello-installer --help` [#15963](http://projects.theforeman.org/issues/15963)

This diff addresses the `--certs-deploy`, `--certs-regenerate`, and `--certs-regenerate-ca` parameters' descriptions, changing them from:

~~~
   --certs-deploy                Deploy the certs on the configured system. False means
                                 we want apply it on a different system (current: true)
...
   --certs-regenerate            Force regeneration of the certificates (excluding
                                 ca certificates) (current: false)
...
   --certs-regenerate-ca         Force regeneration of the ca certificate (current: false)
~~~
To:
~~~
   --certs-deploy                Deploy the certs on the configured system. False means
                                 we want to apply it to a different system (current: true)
...
   --certs-regenerate            Force regeneration of the certificates (excluding
                                 CA certificates) (current: false)
...
   --certs-regenerate-ca         Force regeneration of the CA certificate (current: false)
~~~

Thanks in advance!