### PR TITLE
fixes #24210 - certs group must be overridable

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -17,6 +17,7 @@ class certs::apache (
   $expiration           = $::certs::expiration,
   $default_ca           = $::certs::default_ca,
   $ca_key_password_file = $::certs::ca_key_password_file,
+  $group                = $::certs::group,
 ) inherits certs {
 
   $apache_cert_name = "${hostname}-apache"
@@ -60,7 +61,7 @@ class certs::apache (
       key_file   => $apache_key,
       manage_key => true,
       key_owner  => 'root',
-      key_group  => 'root',
+      key_group  => $group,
       key_mode   => '0440',
       cert_file  => $apache_cert,
     }

--- a/spec/classes/certs_apache_spec.rb
+++ b/spec/classes/certs_apache_spec.rb
@@ -8,4 +8,17 @@ describe 'certs::apache' do
   describe 'with default parameters' do
     it { should compile.with_all_deps }
   end
+
+  describe "with group overridden" do
+    let :pre_condition do
+      "class {'certs': group => 'foreman',}"
+    end
+
+    it { should compile.with_all_deps }
+
+    it do
+      is_expected.to contain_certs__keypair('apache')
+        .with_key_group('foreman')
+    end
+  end
 end


### PR DESCRIPTION
For Katello, we override the certs ownership so Foreman can read it.
This is required for WebVNC: the foreman user launches websockify
using the certificate.

Partially reverts https://github.com/theforeman/puppet-certs/pull/168

