### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,3 @@ fixtures:
     extlib:            "https://github.com/puppet-community/puppet-extlib"
     trusted_ca:        "https://github.com/jlambert121/jlambert121-trusted_ca"
     concat:            "https://github.com/puppetlabs/puppetlabs-concat"
-  symlinks:
-    certs: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically