### PR TITLE
Switch to puppet-trusted_ca & allow puppet-extlib 3.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    stdlib:            "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    extlib:            "https://github.com/puppet-community/puppet-extlib"
-    trusted_ca:        "https://github.com/jlambert121/jlambert121-trusted_ca"
     concat:            "https://github.com/puppetlabs/puppetlabs-concat"
+    extlib:            "https://github.com/voxpupuli/puppet-extlib"
+    stdlib:            "https://github.com/puppetlabs/puppetlabs-stdlib"
+    trusted_ca:        "https://github.com/voxpupuli/puppet-trusted_ca"

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet-extlib",
-      "version_requirement": ">= 0.10.4 < 3.0.0"
+      "version_requirement": ">= 0.10.4 < 4.0.0"
     },
     {
       "name": "puppetlabs-concat",

--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,8 @@
   "issues_url": "https://projects.theforeman.org/projects/katello/issues",
   "dependencies": [
     {
-      "name": "jlambert121-trusted_ca",
-      "version_requirement": ">= 1.0.1 < 2.0.0"
+      "name": "puppet-trusted_ca",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
This fork is maintained and compatible with the latest Puppet and stdlib
versions.

Also cleans up the fixtures to use current URLs.