### PR TITLE
Fixes #25512 fixes incorrect editing of rhsm.conf

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -98,7 +98,7 @@ else
     sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $CFG
   else
     full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a\n$full_refresh_config" $CFG
+    sed -i "/baseurl/a\ $full_refresh_config" $CFG
   fi
 fi
 

--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -98,7 +98,7 @@ else
     sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $CFG
   else
     full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a\ $full_refresh_config" $CFG
+    sed -i "/baseurl/a $full_refresh_config" $CFG
   fi
 fi
 


### PR DESCRIPTION
rhsm-katello-reconfigure.erb template had incorrect sed syntax due to which katello-ca-consumer rpm was creating with incorrect /usr/bin/katello-rhsm-consumer. 