### PR TITLE
Fixes #25739 - don't allow statements to fail in an set -e script

### DIFF
--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -70,10 +70,7 @@ else
   BASEURL=https://$KATELLO_SERVER/pulp/repos
 
   # Get version of RHSM
-  RHSM_V="`rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null | tr . ' '`"
-  if test $? != 0 ; then
-    RHSM_V="0 0 0"
-  fi
+  RHSM_V="`(rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null || echo 0.0.0) | tail -n1 | tr . ' '`"
   declare -a RHSM_VERSION=($RHSM_V)
 
   # configure rhsm
@@ -132,8 +129,8 @@ fi
 if (test -f /etc/redhat-release && grep -q -i "Red Hat Enterprise Linux Server release 5" /etc/redhat-release) || \
    (test -f /etc/centos-release && grep -q -i "CentOS Linux release 5" /etc/centos-release) || \
    test ${RHSM_VERSION[0]:-0} -lt 1 -o ${RHSM_VERSION[1]:-0} -lt 18 -o \( ${RHSM_VERSION[1]:-0} -eq 18 -a ${RHSM_VERSION[2]:-0} -lt 2 \); then
-  FQDN=`hostname -f`
-  if [ $? == "0" ] && [ "$FQDN" != "localhost" ] && [ -d /etc/rhsm/facts/ ]; then
+  FQDN=`hostname -f 2>/dev/null || echo localhost`
+  if [ "$FQDN" != "localhost" ] && [ -d /etc/rhsm/facts/ ]; then
     echo "{\"network.hostname-override\":\"$FQDN\"}" > /etc/rhsm/facts/katello.facts
   fi
 fi

--- a/templates/rhsm-katello-reconfigure.erb
+++ b/templates/rhsm-katello-reconfigure.erb
@@ -70,7 +70,7 @@ else
   BASEURL=https://$KATELLO_SERVER/pulp/repos
 
   # Get version of RHSM
-  RHSM_V="`(rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null || echo 0.0.0) | tail -n1 | tr . ' '`"
+  RHSM_V="$((rpm -q --queryformat='%{VERSION}' subscription-manager 2> /dev/null || echo 0.0.0) | tail -n1 | tr . ' ')"
   declare -a RHSM_VERSION=($RHSM_V)
 
   # configure rhsm
@@ -129,7 +129,7 @@ fi
 if (test -f /etc/redhat-release && grep -q -i "Red Hat Enterprise Linux Server release 5" /etc/redhat-release) || \
    (test -f /etc/centos-release && grep -q -i "CentOS Linux release 5" /etc/centos-release) || \
    test ${RHSM_VERSION[0]:-0} -lt 1 -o ${RHSM_VERSION[1]:-0} -lt 18 -o \( ${RHSM_VERSION[1]:-0} -eq 18 -a ${RHSM_VERSION[2]:-0} -lt 2 \); then
-  FQDN=`hostname -f 2>/dev/null || echo localhost`
+  FQDN="$(hostname -f 2>/dev/null || echo localhost)"
   if [ "$FQDN" != "localhost" ] && [ -d /etc/rhsm/facts/ ]; then
     echo "{\"network.hostname-override\":\"$FQDN\"}" > /etc/rhsm/facts/katello.facts
   fi


### PR DESCRIPTION
When a bash script is executed with `set -e`, it will fail immediately
when a subcommand fails. From bash(1):

    -e    Exit immediately if a pipeline (which may consist of a single
          simple command), a list, or a compound command (see SHELL
          GRAMMAR above), exits with a non-zero status.

Running scripts with `-e` is generally a good idea, but this means that
we can't allow subcommands to fail anymore and then handle the error
case based on `$?`.

This commit replaces the two places where we relied on the value of `$?`
with code that will _never_ fail and at least return a dummy value which
we then can act on.