### PR TITLE
Use FQDNs data types where appropriate

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -12,8 +12,8 @@
 # $certs_tar::                      Path to tar file with certs to generate
 #
 class certs::foreman_proxy_content (
-  String[1] $parent_fqdn = $facts['fqdn'],
-  String $foreman_proxy_fqdn = $facts['fqdn'],
+  Stdlib::Fqdn $parent_fqdn = $::fqdn,
+  Stdlib::Fqdn $foreman_proxy_fqdn = $::fqdn,
   Array[String] $foreman_proxy_cname = [],
   String[1] $certs_tar = undef,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,8 +73,8 @@
 #
 class certs (
   Stdlib::Absolutepath $log_dir = $certs::params::log_dir,
-  String $node_fqdn = $certs::params::node_fqdn,
-  Array[String] $cname = $certs::params::cname,
+  Stdlib::Fqdn $node_fqdn = $certs::params::node_fqdn,
+  Array[Stdlib::Fqdn] $cname = $certs::params::cname,
   Boolean $generate = $certs::params::generate,
   Boolean $regenerate = $certs::params::regenerate,
   Boolean $regenerate_ca = $certs::params::regenerate_ca,

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0 < 6.0.0"
     },
     {
       "name": "puppet-extlib",


### PR DESCRIPTION
This also moves back to the global facts as parameter defaults because it looks like kafo has issues with extracting the proper default.