### PR TITLE
Fixes #26088 - ensure RSA word for SSLProxyMachineCertificateFile

### DIFF
--- a/lib/puppet/provider/katello_ssl_tool.rb
+++ b/lib/puppet/provider/katello_ssl_tool.rb
@@ -175,14 +175,22 @@ module Puppet::Provider::KatelloSslTool
 
     def exists?
       return false unless File.exists?(resource[:path])
-      checksum(expected_content) == checksum(current_content)
+      checksum(expected_content_processed) == checksum(current_content)
     end
 
     def create
-      File.open(resource[:path], "w", mode) { |f| f << expected_content }
+      File.open(resource[:path], "w", mode) { |f| f << expected_content_processed }
     end
 
     protected
+
+    def expected_content_processed
+      content = expected_content
+      if resource[:force_rsa]
+        content.gsub!(/(BEGIN|END) (PRIVATE KEY)/, '\1 RSA \2')
+      end
+      content
+    end
 
     def expected_content
       File.read(source_path)

--- a/lib/puppet/type/certs_common.rb
+++ b/lib/puppet/type/certs_common.rb
@@ -63,6 +63,9 @@ module Certs
 
     newparam(:password_file)
 
+    # ensure RSA string is present in -----(BEGIN/END) (RSA )?PRIVATE KEY-----
+    newparam(:force_rsa)
+
     # make ensure present default
     define_method(:managed?) { true }
 

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -106,7 +106,8 @@ class certs::foreman_proxy (
       key_pair => $server_ca,
     } ~>
     key_bundle { $foreman_proxy_ssl_client_bundle:
-      key_pair => Cert[$foreman_proxy_client_cert_name],
+      key_pair  => Cert[$foreman_proxy_client_cert_name],
+      force_rsa => true,
     } ~>
     file { $foreman_proxy_ssl_client_bundle:
       ensure => file,


### PR DESCRIPTION
Apaches's SSLProxyMachineCertificateFile is not able to find a key
wrapped in `-----BEGIN PRIVATE KEY-----`, which is the format that is
generated when running the server in FIPS mode. It seems that just making
sure the RSA word is there make Apache happy to find the key.

I've added `force_rsa` option for the cert files resources to enforce the
RSA word to be there when wrapping the private key + used that to
generate the client bundle for SSL proxy to use it.