### PR TITLE
Fixes #27847 - Refactor foreman_proxy_content class

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -2,23 +2,25 @@
 #
 # === Parameters:
 #
-# $parent_fqdn::                    FQDN of the parent node. Does not usually
-#                                   need to be set.
-#
 # $foreman_proxy_fqdn::             FQDN of the foreman proxy
 #
 # $foreman_proxy_cname::            additional names of the foreman proxy
 #
 # $certs_tar::                      Path to tar file with certs to generate
 #
+# === Advanced Parameters:
+#
+# $parent_fqdn::                    FQDN of the parent node. Does not usually
+#                                   need to be set.
+#
 class certs::foreman_proxy_content (
-  Stdlib::Fqdn $parent_fqdn = $::fqdn,
-  Stdlib::Fqdn $foreman_proxy_fqdn = $::fqdn,
-  Array[String] $foreman_proxy_cname = [],
-  String[1] $certs_tar = undef,
-) {
+  Stdlib::Fqdn $foreman_proxy_fqdn,
+  Stdlib::Absolutepath $certs_tar,
+  Stdlib::Fqdn $parent_fqdn = $certs::foreman_proxy_content::params::parent_fqdn,
+  Array[Stdlib::Fqdn] $foreman_proxy_cname = [],
+) inherits certs::foreman_proxy_content::params {
 
-  if $foreman_proxy_fqdn == $facts['fqdn'] {
+  if $foreman_proxy_fqdn == $facts['networking']['fqdn'] {
     fail('The hostname is the same as the provided hostname for the foreman-proxy')
   }
 

--- a/manifests/foreman_proxy_content/params.pp
+++ b/manifests/foreman_proxy_content/params.pp
@@ -1,0 +1,11 @@
+# @summary Defaults for certs::foreman_proxy_content::params
+# @api private
+#
+# This class exists because puppet-strings generates a string "[]" rather than
+# an empty array in json for defaults. Kafo also can't handle the hash $facts
+# even though it's the current recommended default. By adding indirection to a
+# class we can work around this.
+class certs::foreman_proxy_content::params {
+  $parent_fqdn = $facts['networking']['fqdn']
+  $foreman_proxy_cname = []
+}

--- a/spec/classes/certs_foreman_proxy_content_spec.rb
+++ b/spec/classes/certs_foreman_proxy_content_spec.rb
@@ -5,22 +5,20 @@ describe 'certs::foreman_proxy_content' do
     on_supported_os['redhat-7-x86_64']
   end
 
-  let :params do
-    {
-      certs_tar: '/tmp/tar',
-      foreman_proxy_fqdn: 'bar.example.com'
-    }
-  end
-
   describe 'with default parameters' do
+    let :params do
+      {
+        certs_tar: '/tmp/tar',
+        foreman_proxy_fqdn: 'bar.example.com'
+      }
+    end
+
     it { should compile.with_all_deps }
   end
 
   context 'with empty certs_tar' do
     let(:params) { { certs_tar: '' } }
 
-    it do
-      should compile.and_raise_error(/\'certs_tar\' expects a String\[1/)
-    end
+    it { should compile.and_raise_error(/\'certs_tar\' expects a Stdlib::Absolutepath/) }
   end
 end


### PR DESCRIPTION
* Move `$parent_fqdn` to Advanced Parameters since users generally don't touch this
* Implement stricter data types
* Use modern facts
* Work around a kafo_parsers/puppet-strings limitation by using class inheritance