### PR TITLE
Fixes #27857 - autorequire parent paths in types

### DIFF
--- a/lib/puppet_x/certs/common.rb
+++ b/lib/puppet_x/certs/common.rb
@@ -95,10 +95,21 @@ module PuppetX
           autorequire_cert('Ca')
         end
 
+        # Autorequire the nearest ancestor directory found in the catalog.
+        # Copied from Puppet's lib/puppet/type/file.rb
         autorequire(:file) do
-          @parameters[:path]
+          req = []
+          path = Pathname.new(self[:path])
+          if !path.root?
+            # Start at our parent, to avoid autorequiring ourself
+            parents = path.parent.enum_for(:ascend)
+            found = parents.find { |p| catalog.resource(:file, p.to_s) }
+            if found
+              req << found.to_s
+            end
+          end
+          req
         end
-
       end
     end
   end

--- a/spec/types/ca_spec.rb
+++ b/spec/types/ca_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'ca' do
+  let(:title) { 'test-ca' }
+
+  it { is_expected.to be_valid_type.with_provider(:katello_ssl_tool) }
+end

--- a/spec/types/cert_spec.rb
+++ b/spec/types/cert_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'cert' do
+  let(:title) { 'test-cert' }
+
+  it { is_expected.to be_valid_type.with_provider(:katello_ssl_tool) }
+end

--- a/spec/types/key_bundle_spec.rb
+++ b/spec/types/key_bundle_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'key_bundle' do
+  let(:title) { 'test-bundle' }
+
+  it { is_expected.to be_valid_type.with_provider(:katello_ssl_tool) }
+
+  describe 'autorequiring' do
+    before :each do
+      @catalog = Puppet::Resource::Catalog.new
+    end
+
+    it "should autorequire files" do
+      @parent = Puppet::Type.type(:file).new(name: '/etc/pki/katello/bundles')
+      @catalog.add_resource @parent
+
+      @resource = Puppet::Type.type(:key_bundle).new(name: title, path: '/etc/pki/katello/bundles/test-bundle.pem')
+      @catalog.add_resource @resource
+
+      req = @resource.autorequire
+      expect(req.size).to eq(1)
+      expect(req[0].target).to eq(@resource)
+      expect(req[0].source).to eq(@parent)
+    end
+  end
+end

--- a/spec/types/privkey_spec.rb
+++ b/spec/types/privkey_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'privkey' do
+  let(:title) { 'test-key' }
+
+  it { is_expected.to be_valid_type.with_provider(:katello_ssl_tool) }
+
+  describe 'autorequiring' do
+    before :each do
+      @catalog = Puppet::Resource::Catalog.new
+    end
+
+    it "should autorequire files" do
+      @parent = Puppet::Type.type(:file).new(name: '/etc/pki/katello/private')
+      @catalog.add_resource @parent
+
+      @resource = Puppet::Type.type(:privkey).new(name: title, path: '/etc/pki/katello/private/key.pem')
+      @catalog.add_resource @resource
+
+      req = @resource.autorequire
+      expect(req.size).to eq(1)
+      expect(req[0].target).to eq(@resource)
+      expect(req[0].source).to eq(@parent)
+    end
+  end
+end

--- a/spec/types/pubkey_spec.rb
+++ b/spec/types/pubkey_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'pubkey' do
+  let(:title) { 'test-pubkey' }
+
+  it { is_expected.to be_valid_type.with_provider(:katello_ssl_tool) }
+
+  describe 'autorequiring' do
+    before :each do
+      @catalog = Puppet::Resource::Catalog.new
+    end
+
+    it "should autorequire files" do
+      @parent = Puppet::Type.type(:file).new(name: '/etc/pki/katello/private')
+      @catalog.add_resource @parent
+
+      @resource = Puppet::Type.type(:pubkey).new(name: title, path: '/etc/pki/katello/private/key.pem')
+      @catalog.add_resource @resource
+
+      req = @resource.autorequire
+      expect(req.size).to eq(1)
+      expect(req[0].target).to eq(@resource)
+      expect(req[0].source).to eq(@parent)
+    end
+  end
+end


### PR DESCRIPTION
Before the patch only the path itself was autorequired but this copies the autorequire from Puppet's file which autorequires all parts of the path to the root. This ensures that the parent directory exists before the provider attempts to write the file and fixes errors like:

[ERROR 2019-09-14T04:58:09 main] Could not set 'present' on ensure: No such file or directory @ rb_sysopen - /etc/pki/katello/private/katello-apache.key (file: /usr/share/foreman-installer/modules/certs/manifests/keypair.pp, line: 18)
[ WARN 2019-09-14T04:58:25 main] /Stage[main]/Certs::Config/File[/etc/pki/katello/private]/ensure: created

Also adds minimal spec tests for ca and cert types.