### PR TITLE
Refs #27847 - Load CNAME default from params

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -17,7 +17,7 @@ class certs::foreman_proxy_content (
   Stdlib::Fqdn $foreman_proxy_fqdn,
   Stdlib::Absolutepath $certs_tar,
   Stdlib::Fqdn $parent_fqdn = $certs::foreman_proxy_content::params::parent_fqdn,
-  Array[Stdlib::Fqdn] $foreman_proxy_cname = [],
+  Array[Stdlib::Fqdn] $foreman_proxy_cname = $certs::foreman_proxy_content::params::foreman_proxy_cname,
 ) inherits certs::foreman_proxy_content::params {
 
   if $foreman_proxy_fqdn == $facts['networking']['fqdn'] {


### PR DESCRIPTION
3beda1df35481210b581f9beeb63d1dcafd2aca0 intended to load the variable from params and even added it to params.pp, but missed using that variable.