### PR TITLE
Refs #27847 - Use legacy facts

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -20,7 +20,7 @@ class certs::foreman_proxy_content (
   Array[Stdlib::Fqdn] $foreman_proxy_cname = $certs::foreman_proxy_content::params::foreman_proxy_cname,
 ) inherits certs::foreman_proxy_content::params {
 
-  if $foreman_proxy_fqdn == $facts['networking']['fqdn'] {
+  if $foreman_proxy_fqdn == $facts['fqdn'] {
     fail('The hostname is the same as the provided hostname for the foreman-proxy')
   }
 

--- a/manifests/foreman_proxy_content/params.pp
+++ b/manifests/foreman_proxy_content/params.pp
@@ -6,6 +6,6 @@
 # even though it's the current recommended default. By adding indirection to a
 # class we can work around this.
 class certs::foreman_proxy_content::params {
-  $parent_fqdn = $facts['networking']['fqdn']
+  $parent_fqdn = $facts['fqdn']
   $foreman_proxy_cname = []
 }


### PR DESCRIPTION
In foreman-installer we test the command inside bundler. There is only a facter 2 gem which doesn't have the modern facts. That means `$facts['networking']` is `undef` and breaks, even though this won't be a problem in production. In many places we still use legacy facts so this reverts back to legacy facts.