### PR TITLE
Remove unused $regenerate_ca parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,8 +38,6 @@
 # $regenerate::           Force regeneration of the certificates (excluding
 #                         CA certificates)
 #
-# $regenerate_ca::        Force regeneration of the CA certificate
-#
 # $deploy::               Deploy the certs on the configured system. False means
 #                         we want to apply it to a different system
 #
@@ -77,7 +75,6 @@ class certs (
   Array[Stdlib::Fqdn] $cname = $certs::params::cname,
   Boolean $generate = $certs::params::generate,
   Boolean $regenerate = $certs::params::regenerate,
-  Boolean $regenerate_ca = $certs::params::regenerate_ca,
   Boolean $deploy = $certs::params::deploy,
   String $ca_common_name = $certs::params::ca_common_name,
   String[2,2] $country = $certs::params::country,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@ class certs::params {
   $ca_common_name = $facts['fqdn']  # we need fqdn as CA common name as candlepin uses it as a ssl cert
   $generate      = true
   $regenerate    = false
-  $regenerate_ca = false
   $deploy        = true
 
   $default_ca_name = 'katello-default-ca'


### PR DESCRIPTION
d4a730d70e02a393a9dc265184e3e8f87a7b86e8 stopped using this parameter and there's nothing using it anymore.