### PR TITLE
Bump major version to 7.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-certs",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "author": "katello",
   "summary": "Deploys CA and required certs for a Foreman and Katello installation.",
   "license": "GPL-3.0+",


### PR DESCRIPTION
Due to ec654e3f6ea563fb9bfb7de48fc3c58ccae10a8d and 23faa5462d0e8a1ddafb86304e4749c1ab6a5f7a which are both breaking.