### PR TITLE
Move repository setup to the spec helper & drop EPEL

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,5 +10,3 @@ Rakefile:
   param_docs_pattern:
     - manifests/foreman_proxy_content.pp
     - manifests/init.pp
-spec/spec_helper_acceptance.rb:
-  install_epel: true

--- a/spec/acceptance/apache_spec.rb
+++ b/spec/acceptance/apache_spec.rb
@@ -1,19 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'certs::apache' do
-  before(:all) do
-    install_repo = <<-EOS
-      yumrepo { 'katello':
-        descr    => 'Katello latest',
-        baseurl  => 'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/$basearch/',
-        gpgcheck => false,
-        enabled  => true,
-      }
-    EOS
-
-    apply_manifest(install_repo)
-  end
-
   context 'with default parameters' do
     let(:pp) do
       'include certs::apache'

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -1,19 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'certs' do
-  before(:all) do
-    install_repo = <<-EOS
-      yumrepo { 'katello':
-        descr    => 'Katello latest',
-        baseurl  => 'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/$basearch/',
-        gpgcheck => false,
-        enabled  => true,
-      }
-    EOS
-
-    apply_manifest(install_repo)
-  end
-
   keystore_password_file = '/etc/pki/katello/keystore_password-file'
 
   context 'with default params' do

--- a/spec/acceptance/certs_spec.rb
+++ b/spec/acceptance/certs_spec.rb
@@ -1,19 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'certs' do
-  before(:all) do
-    install_repo = <<-EOS
-      yumrepo { 'katello':
-        descr    => 'Katello latest',
-        baseurl  => 'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/$basearch/',
-        gpgcheck => false,
-        enabled  => true,
-      }
-    EOS
-
-    apply_manifest(install_repo)
-  end
-
   context 'with default params' do
     let(:pp) do
       'include certs'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,8 +28,6 @@ RSpec.configure do |c|
         on host, 'sed -i "s/keepcache=.*/keepcache=1/" /etc/yum.conf'
         # refresh check if cache needs refresh on next yum command
         on host, 'yum clean expire-cache'
-        # We always need EPEL
-        on host, puppet('resource', 'package', 'epel-release', 'ensure=installed')
       end
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,6 +28,8 @@ RSpec.configure do |c|
         on host, 'sed -i "s/keepcache=.*/keepcache=1/" /etc/yum.conf'
         # refresh check if cache needs refresh on next yum command
         on host, 'yum clean expire-cache'
+        # foreman nightly provides katello-cert-tools
+        host.install_package('https://yum.theforeman.org/releases/nightly/el7/x86_64/foreman-release.rpm')
       end
     end
   end


### PR DESCRIPTION
This also replaces latest katello with foreman nightly. Katello latest points to 3.8 where in later releases katello-certs-tools was moved to the Foreman repository. EPEL was actually unused.