### PR TITLE
Remove unused $katello_* params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,7 +73,6 @@ class certs::params {
   $qpid_router_owner       = 'qdrouterd'
   $qpid_router_group       = 'root'
 
-  $pulp_server_ca_cert   = '/etc/pki/pulp/server_ca.crt'
   # Pulp expects the node certificate to be located on this very location
   $nodes_cert_dir        = '/etc/pki/pulp/nodes'
   $nodes_cert_name       = 'node.crt'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,10 +73,6 @@ class certs::params {
   $qpid_router_owner       = 'qdrouterd'
   $qpid_router_group       = 'root'
 
-  # Pulp expects the node certificate to be located on this very location
-  $nodes_cert_dir        = '/etc/pki/pulp/nodes'
-  $nodes_cert_name       = 'node.crt'
-
   $qpidd_group = 'qpidd'
 
   $tar_file = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,8 +8,6 @@ class certs::params {
   $node_fqdn = $facts['networking']['fqdn']
   $cname = []
 
-  $custom_repo = false
-
   $ca_common_name = $facts['networking']['fqdn']  # we need fqdn as CA common name as candlepin uses it as a ssl cert
   $generate      = true
   $regenerate    = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,14 +63,6 @@ class certs::params {
   $candlepin_ca_cert                = "${candlepin_certs_dir}/candlepin-ca.crt"
   $candlepin_ca_key                 = "${candlepin_certs_dir}/candlepin-ca.key"
 
-  # Settings for uploading packages to Katello
-  $katello_user           = undef
-  $katello_password       = undef
-  $katello_org            = 'Katello Infrastructure'
-  $katello_repo_provider  = 'node-installer'
-  $katello_product        = 'node-certs'
-  $katello_activation_key = undef
-
   $pulp_pki_dir = '/etc/pki/pulp'
 
   $qpid_client_cert = "${pulp_pki_dir}/qpid/client.crt"


### PR DESCRIPTION
5f2f0557606241a2bb08e5f798a3a231b72cbf38 removed the use of these variables but didn't remove the definitions.