### PR TITLE
Move cname default back to params.pp due to Kafo improperly handling validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@
 #
 class certs (
   Stdlib::Fqdn $node_fqdn = $certs::params::node_fqdn,
-  Array[Stdlib::Fqdn] $cname = [],
+  Array[Stdlib::Fqdn] $cname = $certs::params::cname,
   Boolean $generate = true,
   Boolean $regenerate = false,
   Boolean $deploy = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,8 @@ class certs::params {
 
   $ca_common_name = $facts['networking']['fqdn']  # we need fqdn as CA common name as candlepin uses it as a ssl cert
 
+  $cname = [] # Kafo cannot handle Array types as static parameters, https://projects.theforeman.org/issues/31565
+
   $puppet_client_cert = "${pki_dir}/puppet/puppet_client.crt"
   $puppet_client_key  = "${pki_dir}/puppet/puppet_client.key"
   # for verifying the foreman https


### PR DESCRIPTION
Fixes the following error during validation:

Parameter certs-cname invalid: Elements of the array are invalid: [] must match one of
(?-mix:\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z