### PR TITLE
Revert "Convert foreman_proxy_content.pp parameters to static defaults"

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -17,7 +17,7 @@ class certs::foreman_proxy_content (
   Stdlib::Fqdn $foreman_proxy_fqdn,
   Stdlib::Absolutepath $certs_tar,
   Stdlib::Fqdn $parent_fqdn = $certs::foreman_proxy_content::params::parent_fqdn,
-  Array[Stdlib::Fqdn] $foreman_proxy_cname = [],
+  Array[Stdlib::Fqdn] $foreman_proxy_cname = $certs::foreman_proxy_content::params::foreman_proxy_cname,
 ) inherits certs::foreman_proxy_content::params {
 
   if $foreman_proxy_fqdn == $facts['networking']['fqdn'] {

--- a/manifests/foreman_proxy_content/params.pp
+++ b/manifests/foreman_proxy_content/params.pp
@@ -7,4 +7,5 @@
 # class we can work around this.
 class certs::foreman_proxy_content::params {
   $parent_fqdn = $facts['networking']['fqdn']
+  $foreman_proxy_cname = []
 }


### PR DESCRIPTION
This reverts commit 920130e781c2e31c6b4598a7df1b911443bd6f50. Similar to 6be51bcdbc571f6c926624be24e585edc9593e89 this causes problems. params.pp already states exactly why the workaround is there, but this was not read and wasn't seen in review either.