### PR TITLE
Fixes #31574: Ensure truststore certificates get updated when they change

### DIFF
--- a/lib/puppet/provider/truststore_certificate/keytool.rb
+++ b/lib/puppet/provider/truststore_certificate/keytool.rb
@@ -1,0 +1,90 @@
+Puppet::Type.type(:truststore_certificate).provide(:keytool) do
+  commands :keytool => 'keytool'
+  commands :openssl => 'openssl'
+
+  def create
+    add_certificate
+  end
+
+  def destroy
+    delete_certificate
+  end
+
+  def exists?
+    truststore_content
+  end
+
+  def certificate
+    truststore_fingerprint
+  end
+
+  def certificate=(value)
+    delete_certificate unless truststore_content.nil?
+    add_certificate
+  end
+
+  def fingerprint(file)
+    return unless File.exist?(file)
+
+    openssl('x509', '-noout', '-fingerprint', '-in', file).strip.split('=')[1]
+  end
+
+  def file_readable?(file)
+    File.file?(file) && File.readable?(file)
+  end
+
+  private
+
+  def add_certificate
+    keytool(
+      '-import',
+      '-v',
+      '-noprompt',
+      '-storetype',
+      'pkcs12',
+      '-keystore',
+      resource[:truststore],
+      '-alias',
+      resource[:alias],
+      '-file',
+      resource[:certificate],
+      '-storepass:file',
+      resource[:password_file]
+    )
+  end
+
+  def delete_certificate
+    keytool(
+      '-delete',
+      '-v',
+      '-noprompt',
+      '-keystore',
+      resource[:truststore],
+      '-alias',
+      resource[:alias],
+      '-storepass:file',
+      resource[:password_file]
+    )
+  end
+
+  def truststore_content
+    return unless file_readable?(resource[:truststore])
+    return unless file_readable?(resource[:password_file])
+
+    keytool(
+      '-list',
+      '-keystore', resource[:truststore],
+      '-storepass:file', resource[:password_file],
+      '-alias', resource[:alias],
+    )
+  rescue Puppet::ExecutionFailure => e
+    Puppet.debug("Failed to read truststore contents: #{e}")
+    # TODO: distinguish between invalid password, alias doesn't exist and others?
+    nil
+  end
+
+  def truststore_fingerprint
+    # TODO: include fingerprint type in the output?
+    truststore_content&.scan(/^Certificate fingerprint \(SHA1\): (.+)$/)&.first&.first
+  end
+end

--- a/lib/puppet/type/truststore_certificate.rb
+++ b/lib/puppet/type/truststore_certificate.rb
@@ -1,0 +1,47 @@
+Puppet::Type.newtype(:truststore_certificate) do
+  desc 'adds a certificate to a pkcs12 truststore'
+
+  ensurable
+
+  def self.title_patterns
+    [ [ /(.+):(.+)/m, [ [:truststore], [:alias] ] ] ]
+  end
+
+  newparam(:alias, :namevar => true) do
+    desc "The certificate alias used to store inside the truststore"
+  end
+
+  newparam(:truststore, :namevar => true) do
+    desc "Path to the truststore to use or create when importing the certificate"
+    isrequired
+  end
+
+  newproperty(:certificate) do
+    desc "Path to the certificate to add to the truststore"
+
+    def fingerprint(file)
+      provider.fingerprint(file)
+    end
+
+    def should_to_s(newvalue)
+      self.class.format_value_for_display(fingerprint(newvalue))
+    end
+
+    def insync?(is)
+      is == fingerprint(should)
+    end
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the truststore password"
+    isrequired
+  end
+
+  autorequire(:file) do
+    [self[:password_file], File.dirname(self[:truststore]), self[:certificate]]
+  end
+
+  autonotify(:file) do
+    [self[:truststore]]
+  end
+end

--- a/manifests/keypair.pp
+++ b/manifests/keypair.pp
@@ -1,18 +1,19 @@
+# Deploy a key pair
 define certs::keypair (
   $key_pair,
-  $key_file,
-  $cert_file,
-  $manage_key  = false,
-  $key_owner   = undef,
-  $key_group   = undef,
-  $key_mode    = undef,
-  $manage_cert = false,
-  $cert_owner  = undef,
-  $cert_group  = undef,
-  $cert_mode   = undef,
-  $unprotect   = false,
-  $strip       = false,
-  $password_file = undef,
+  Stdlib::Absolutepath $key_file,
+  Stdlib::Absolutepath $cert_file,
+  Boolean $manage_key = false,
+  Optional[String[1]] $key_owner = undef,
+  Optional[String[1]] $key_group = undef,
+  Optional[Stdlib::Filemode] $key_mode = undef,
+  Boolean $manage_cert = false,
+  Optional[String[1]] $cert_owner = undef,
+  Optional[String[1]] $cert_group = undef,
+  Optional[Stdlib::Filemode] $cert_mode = undef,
+  Boolean $unprotect = false,
+  Boolean $strip = false,
+  Optional[Stdlib::Absolutepath] $password_file = undef,
 ) {
   $key_pair ~>
   privkey { $key_file:

--- a/spec/classes/certs_candlepin_spec.rb
+++ b/spec/classes/certs_candlepin_spec.rb
@@ -8,7 +8,34 @@ describe 'certs::candlepin' do
       end
 
       describe 'with default parameters' do
-        it { should compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_certs__keypair('candlepin-ca') }
+        it { is_expected.to contain_pubkey('/etc/candlepin/certs/candlepin-ca.crt').that_comes_before('File[/etc/candlepin/certs/candlepin-ca.crt]') }
+        it { is_expected.to contain_file('/etc/candlepin/certs/candlepin-ca.crt') }
+        it { is_expected.to contain_privkey('/etc/candlepin/certs/candlepin-ca.key').that_comes_before('File[/etc/candlepin/certs/candlepin-ca.key]') }
+        it { is_expected.to contain_file('/etc/candlepin/certs/candlepin-ca.key') }
+
+        it { is_expected.to contain_certs__keypair('tomcat') }
+        it { is_expected.to contain_cert('foo.example.com-tomcat').with_ca('Ca[katello-default-ca]') }
+        it { is_expected.to contain_privkey('/etc/pki/katello/private/katello-tomcat.key') }
+        it { is_expected.to contain_pubkey('/etc/pki/katello/certs/katello-tomcat.crt') }
+
+        it { is_expected.to contain_certs__keypair('candlepin') }
+        it { is_expected.to contain_cert('java-client').with_ca('Ca[katello-default-ca]') }
+        it { is_expected.to contain_pubkey('/etc/pki/katello/certs/java-client.crt').that_comes_before('File[/etc/pki/katello/certs/java-client.crt]') }
+        it { is_expected.to contain_file('/etc/pki/katello/certs/java-client.crt') }
+        it { is_expected.to contain_privkey('/etc/pki/katello/private/java-client.key').that_comes_before('File[/etc/pki/katello/private/java-client.key]') }
+        it { is_expected.to contain_file('/etc/pki/katello/private/java-client.key') }
+
+        it { is_expected.to contain_file('/etc/candlepin/certs/keystore') }
+        it { is_expected.to contain_file('/etc/pki/katello/keystore_password-file') }
+        it { is_expected.to contain_exec('candlepin-generate-ssl-keystore').that_notifies('File[/etc/candlepin/certs/keystore]') }
+
+        it { is_expected.to contain_file('/etc/candlepin/certs/truststore') }
+        it { is_expected.to contain_file('/etc/pki/katello/truststore_password-file') }
+        it { is_expected.to contain_exec('Create Candlepin truststore with CA').that_notifies('File[/etc/candlepin/certs/truststore]') }
+        it { is_expected.to contain_exec('import client certificate into Candlepin truststore').that_subscribes_to('File[/etc/candlepin/certs/truststore]') }
       end
     end
   end

--- a/spec/classes/certs_candlepin_spec.rb
+++ b/spec/classes/certs_candlepin_spec.rb
@@ -34,8 +34,31 @@ describe 'certs::candlepin' do
 
         it { is_expected.to contain_file('/etc/candlepin/certs/truststore') }
         it { is_expected.to contain_file('/etc/pki/katello/truststore_password-file') }
-        it { is_expected.to contain_exec('Create Candlepin truststore with CA').that_notifies('File[/etc/candlepin/certs/truststore]') }
-        it { is_expected.to contain_exec('import client certificate into Candlepin truststore').that_subscribes_to('File[/etc/candlepin/certs/truststore]') }
+        it do
+          is_expected.to contain_truststore_certificate('/etc/candlepin/certs/truststore:candlepin-ca')
+            .with_alias('candlepin-ca')
+            .with_certificate('/etc/candlepin/certs/candlepin-ca.crt')
+            .that_requires('File[/etc/candlepin/certs/candlepin-ca.crt]')
+            .with_truststore('/etc/candlepin/certs/truststore')
+            .with_password_file('/etc/pki/katello/truststore_password-file')
+            .that_requires('File[/etc/pki/katello/truststore_password-file]')
+            # TODO: rspec-puppet doesn't support autonotify
+            # https://github.com/rodjek/rspec-puppet/pull/819
+            #.that_notifies('File[/etc/candlepin/certs/truststore]')
+        end
+
+        it do
+          is_expected.to contain_truststore_certificate('/etc/candlepin/certs/truststore:artemis-client')
+            .with_alias('artemis-client')
+            .with_certificate('/etc/pki/katello/certs/java-client.crt')
+            .that_requires('File[/etc/pki/katello/certs/java-client.crt]')
+            .with_truststore('/etc/candlepin/certs/truststore')
+            .with_password_file('/etc/pki/katello/truststore_password-file')
+            .that_requires('File[/etc/pki/katello/truststore_password-file]')
+            # TODO: rspec-puppet doesn't support autonotify
+            # https://github.com/rodjek/rspec-puppet/pull/819
+            #.that_notifies('File[/etc/candlepin/certs/truststore]')
+        end
       end
     end
   end

--- a/spec/defines/keypair_spec.rb
+++ b/spec/defines/keypair_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'certs::keypair' do
+  let(:title) { 'mykeypair' }
+  let(:params) do
+    {
+      key_pair: 'Ca[default]',
+      key_file: '/path/to/key.pem',
+      cert_file: '/path/to/cert.pem',
+    }
+  end
+  let(:pre_condition) do
+    <<-PUPPET
+    ca { 'default':
+    }
+    PUPPET
+  end
+
+  context 'with minimal parameters' do
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_privkey('/path/to/key.pem')
+        .with_key_pair('Ca[default]')
+        .with_unprotect(false)
+        .with_password_file(nil)
+        .that_subscribes_to('Ca[default]')
+    end
+
+    it do
+      is_expected.to contain_pubkey('/path/to/cert.pem')
+        .with_key_pair('Ca[default]')
+        .with_strip(false)
+        .that_subscribes_to(['Ca[default]', 'Privkey[/path/to/key.pem]'])
+    end
+
+    it { is_expected.not_to contain_file('/path/to/key.pem') }
+    it { is_expected.not_to contain_file('/path/to/cert.pem') }
+  end
+
+  context 'with manage_key => true' do
+    let(:params) { super().merge(manage_key: true) }
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_file('/path/to/key.pem').that_requires('Privkey[/path/to/key.pem]') }
+    it { is_expected.not_to contain_file('/path/to/cert.pem') }
+  end
+
+  context 'with manage_cert => true' do
+    let(:params) { super().merge(manage_cert: true) }
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_file('/path/to/key.pem') }
+    it { is_expected.to contain_file('/path/to/cert.pem').that_requires('Pubkey[/path/to/cert.pem]') }
+  end
+end


### PR DESCRIPTION
Alternative to https://github.com/theforeman/puppet-certs/pull/311. This implementation takes the approach of trying to figure out the fingerprints for the certificate property. This means that the changed value is also more readable.

There is a bit of overhead since keytool and openssl are called multiple times with the same parameters. These were pretty fast and I figured that caching was more likely to break something than to improve it.

Some manual verification. If we decide to go this route, I can convert them to automated tests.

```console
# ls /etc/candlepin/certs/truststore2
ls: cannot access /etc/candlepin/certs/truststore2: No such file or directory
# puppet resource truststore_certificate candlepin-ca2 truststore=/etc/candlepin/certs/truststore2 password_file=/etc/pki/katello/truststore_password-file
truststore_certificate { 'candlepin-ca2':
  ensure   => 'absent',
  provider => 'truststore_certificate',
}
# puppet resource truststore_certificate candlepin-ca2 truststore=/etc/candlepin/certs/truststore2 password_file=/etc/pki/katello/truststore_password-file certificate=/etc/candlepin/certs/candlepin-ca.crt
Notice: /Truststore_certificate[candlepin-ca2]/ensure: created
truststore_certificate { 'candlepin-ca2':
  ensure      => 'present',
  certificate => '5E:3F:23:30:46:5F:1A:70:E4:45:85:87:B9:6A:7B:39:20:9B:DF:83',
  provider    => 'truststore_certificate',
}
# puppet resource truststore_certificate candlepin-ca2 truststore=/etc/candlepin/certs/truststore2 password_file=/etc/pki/katello/truststore_password-file certificate=/etc/pki/katello-certs-tools/certs/centos7-64.example.com-tomcat.crt
Notice: /Truststore_certificate[candlepin-ca2]/certificate: certificate changed '5E:3F:23:30:46:5F:1A:70:E4:45:85:87:B9:6A:7B:39:20:9B:DF:83' to '02:7D:1F:42:86:22:54:27:A8:20:5C:43:4F:87:0D:E8:06:50:AD:4B'
truststore_certificate { 'candlepin-ca2':
  ensure      => 'present',
  certificate => '02:7D:1F:42:86:22:54:27:A8:20:5C:43:4F:87:0D:E8:06:50:AD:4B',
  provider    => 'truststore_certificate',
}
# puppet resource truststore_certificate candlepin-ca2 truststore=/etc/candlepin/certs/truststore2 password_file=/etc/pki/katello/truststore_password-file ensure=absent
Notice: /Truststore_certificate[candlepin-ca2]/ensure: removed
truststore_certificate { 'candlepin-ca2':
  ensure   => 'absent',
  provider => 'truststore_certificate',
}
# /bin/keytool -list -keystore /etc/candlepin/certs/truststore2 -storepass:file /etc/pki/katello/truststore_password-file
Keystore type: PKCS12
Keystore provider: SUN

Your keystore contains 0 entries
```