### PR TITLE
Fixes #31574: Ensure truststore certificates get updated when they change

### DIFF
--- a/lib/puppet/provider/truststore_certificate/keytool.rb
+++ b/lib/puppet/provider/truststore_certificate/keytool.rb
@@ -1,0 +1,90 @@
+Puppet::Type.type(:truststore_certificate).provide(:keytool) do
+  commands :keytool => 'keytool'
+  commands :openssl => 'openssl'
+
+  def create
+    add_certificate
+  end
+
+  def destroy
+    delete_certificate
+  end
+
+  def exists?
+    truststore_content
+  end
+
+  def certificate
+    truststore_fingerprint
+  end
+
+  def certificate=(value)
+    delete_certificate unless truststore_content.nil?
+    add_certificate
+  end
+
+  def fingerprint(file)
+    return unless File.exist?(file)
+
+    openssl('x509', '-noout', '-fingerprint', '-in', file).strip.split('=')[1]
+  end
+
+  def file_readable?(file)
+    File.file?(file) && File.readable?(file)
+  end
+
+  private
+
+  def add_certificate
+    keytool(
+      '-import',
+      '-v',
+      '-noprompt',
+      '-storetype',
+      'pkcs12',
+      '-keystore',
+      resource[:truststore],
+      '-alias',
+      resource[:alias],
+      '-file',
+      resource[:certificate],
+      '-storepass:file',
+      resource[:password_file]
+    )
+  end
+
+  def delete_certificate
+    keytool(
+      '-delete',
+      '-v',
+      '-noprompt',
+      '-keystore',
+      resource[:truststore],
+      '-alias',
+      resource[:alias],
+      '-storepass:file',
+      resource[:password_file]
+    )
+  end
+
+  def truststore_content
+    return unless file_readable?(resource[:truststore])
+    return unless file_readable?(resource[:password_file])
+
+    keytool(
+      '-list',
+      '-keystore', resource[:truststore],
+      '-storepass:file', resource[:password_file],
+      '-alias', resource[:alias],
+    )
+  rescue Puppet::ExecutionFailure => e
+    Puppet.debug("Failed to read truststore contents: #{e}")
+    # TODO: distinguish between invalid password, alias doesn't exist and others?
+    nil
+  end
+
+  def truststore_fingerprint
+    # TODO: include fingerprint type in the output?
+    truststore_content&.scan(/^Certificate fingerprint \(SHA1\): (.+)$/)&.first&.first
+  end
+end

--- a/lib/puppet/type/truststore_certificate.rb
+++ b/lib/puppet/type/truststore_certificate.rb
@@ -1,0 +1,47 @@
+Puppet::Type.newtype(:truststore_certificate) do
+  desc 'adds a certificate to a pkcs12 truststore'
+
+  ensurable
+
+  def self.title_patterns
+    [ [ /(.+):(.+)/m, [ [:truststore], [:alias] ] ] ]
+  end
+
+  newparam(:alias, :namevar => true) do
+    desc "The certificate alias used to store inside the truststore"
+  end
+
+  newparam(:truststore, :namevar => true) do
+    desc "Path to the truststore to use or create when importing the certificate"
+    isrequired
+  end
+
+  newproperty(:certificate) do
+    desc "Path to the certificate to add to the truststore"
+
+    def fingerprint(file)
+      provider.fingerprint(file)
+    end
+
+    def should_to_s(newvalue)
+      self.class.format_value_for_display(fingerprint(newvalue))
+    end
+
+    def insync?(is)
+      is == fingerprint(should)
+    end
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the truststore password"
+    isrequired
+  end
+
+  autorequire(:file) do
+    [self[:password_file], File.dirname(self[:truststore]), self[:certificate]]
+  end
+
+  autonotify(:file) do
+    [self[:truststore]]
+  end
+end


### PR DESCRIPTION
This combines https://github.com/theforeman/puppet-certs/pull/312 with the updated testing from https://github.com/theforeman/puppet-certs/pull/311/files#diff-5afea89f9f4123c60bf87969c1a02b0d75c0687a14758480314204b44ca679c1R189 to get to a PR that resolves this issue and we can pull in. There have been additional reports of users hitting this issue.