### PR TITLE
Refs #31574: Compare SHA256 fingerprints when checking truststore

### DIFF
--- a/lib/puppet/provider/truststore_certificate/keytool.rb
+++ b/lib/puppet/provider/truststore_certificate/keytool.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:truststore_certificate).provide(:keytool) do
   def fingerprint(file)
     return unless File.exist?(file)
 
-    openssl('x509', '-noout', '-fingerprint', '-in', file).strip.split('=')[1]
+    openssl('x509', '-sha256', '-noout', '-fingerprint', '-in', file).strip.split('=')[1]
   end
 
   def file_readable?(file)
@@ -85,6 +85,6 @@ Puppet::Type.type(:truststore_certificate).provide(:keytool) do
 
   def truststore_fingerprint
     # TODO: include fingerprint type in the output?
-    truststore_content&.scan(/^Certificate fingerprint \(SHA1\): (.+)$/)&.first&.first
+    truststore_content&.scan(/^Certificate fingerprint \(SHA-256\): (.+)$/)&.first&.first
   end
 end

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -106,7 +106,7 @@ class certs::candlepin (
     } ~>
     exec { 'candlepin-generate-ssl-keystore':
       command   => "openssl pkcs12 -export -in ${tomcat_cert} -inkey ${tomcat_key} -out ${keystore} -name tomcat -CAfile ${ca_cert} -caname root -password \"file:${keystore_password_path}\"",
-      unless    => "keytool -list -keystore ${keystore} -storepass:file ${keystore_password_path} -alias tomcat | grep $(openssl x509 -noout -fingerprint -in ${tomcat_cert} | cut -d '=' -f 2)",
+      unless    => "keytool -list -keystore ${keystore} -storepass:file ${keystore_password_path} -alias tomcat | grep $(openssl x509 -noout -fingerprint -sha256 -in ${tomcat_cert} | cut -d '=' -f 2)",
       logoutput => 'on_failure',
       path      => ['/bin/', '/usr/bin'],
     } ~>

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -189,7 +189,7 @@ describe 'certs' do
     it "checks that the fingerprint matches" do
       apply_manifest(pp, catch_failures: true)
 
-      initial_fingerprint_output = on default, 'openssl x509 -noout -fingerprint -in /etc/pki/katello/certs/java-client.crt'
+      initial_fingerprint_output = on default, 'openssl x509 -noout -fingerprint -sha256 -in /etc/pki/katello/certs/java-client.crt'
       initial_fingerprint = initial_fingerprint_output.output.strip.split('=').last
       initial_truststore_output = on default, "keytool -list -keystore /etc/candlepin/certs/truststore -storepass $(cat #{truststore_password_file})"
       expect(initial_truststore_output.output.strip).to include(initial_fingerprint)
@@ -197,7 +197,7 @@ describe 'certs' do
       on default, "rm -rf /root/ssl-build/#{host_inventory['fqdn']}"
       apply_manifest(pp, catch_failures: true)
 
-      fingerprint_output = on default, 'openssl x509 -noout -fingerprint -in /etc/pki/katello/certs/java-client.crt'
+      fingerprint_output = on default, 'openssl x509 -noout -fingerprint -sha256 -in /etc/pki/katello/certs/java-client.crt'
       fingerprint = fingerprint_output.output.strip.split('=').last
       truststore_output = on default, "keytool -list -keystore /etc/candlepin/certs/truststore -storepass $(cat #{truststore_password_file})"
 


### PR DESCRIPTION
I'm very confused. Between the last time https://github.com/theforeman/puppet-certs/pull/320 ran which as March 17th, something has changed that causes the idempotency of this new type and provider to break.  This only seems to occur on EL7. I have added two debug statements here that highlight so far what I know which is that the `is` value is nil when doing the `insync?` check.