### PR TITLE
Fixes #32506: Add an nssdb_certificate type and provider 

### DIFF
--- a/lib/puppet/provider/nssdb_certificate/certutil.rb
+++ b/lib/puppet/provider/nssdb_certificate/certutil.rb
@@ -1,0 +1,117 @@
+Puppet::Type.type(:nssdb_certificate).provide(:certutil) do
+  commands :certutil => 'certutil'
+  commands :openssl => 'openssl'
+  commands :pk12util => 'pk12util'
+
+  def create
+    add_certificate
+    add_private_key if resource[:private_key]
+  end
+
+  def destroy
+    delete_certificate
+    delete_private_key if resource[:private_key]
+  end
+
+  def exists?
+    nssdb_content
+  end
+
+  def certificate
+    nssdb_fingerprint
+  end
+
+  def certificate=(value)
+    delete_certificate unless nssdb_content.nil?
+    add_certificate
+  end
+
+  def fingerprint(file)
+    return unless File.exist?(file)
+
+    openssl('x509', '-sha256', '-noout', '-fingerprint', '-in', file).strip.split('=')[1]
+  rescue Puppet::ExecutionFailure => e
+    Puppet.warn("Failed to read certificate #{file}: #{e}")
+    nil
+  end
+
+  private
+
+  def add_certificate
+    certutil(
+      '-A',
+      '-a',
+      '-d', resource[:nssdb],
+      '-n', resource[:cert_name],
+      '-t', resource[:trustargs],
+      '-i', resource[:certificate],
+      '-f', resource[:password_file]
+    )
+  end
+
+  def delete_certificate
+    certutil(
+      '-D',
+      '-d', resource[:nssdb],
+      '-n', resource[:cert_name]
+    )
+  end
+
+  def add_private_key
+    Tempfile.open('pkcs12') do |pkcs12|
+      openssl(
+        'pkcs12',
+        '-export',
+        '-in', resource[:certificate],
+        '-inkey', resource[:private_key],
+        '-out', pkcs12.path,
+        '-password', "file:#{resource[:password_file]}",
+        '-name', resource[:cert_name]
+      )
+
+      pk12util(
+        '-i', pkcs12.path,
+        '-d', resource[:nssdb],
+        '-w', resource[:password_file],
+        '-k', resource[:password_file]
+      )
+    end
+  end
+
+  def delete_private_key
+    certutil(
+      '-F',
+      '-d', resource[:nssdb],
+      '-n', resource[:cert_name]
+    )
+  end
+
+  def nssdb_content
+    return unless directory_readable?(resource[:nssdb])
+
+    certutil(
+      '-L',
+      '-a',
+      '-d', resource[:nssdb],
+      '-n', resource[:cert_name]
+    )
+  rescue Puppet::ExecutionFailure => e
+    Puppet.debug("Failed to read nssdb contents from #{resource[:nssdb]}: #{e}")
+    nil
+  end
+
+  def nssdb_fingerprint
+    cert_info = nssdb_content
+    return unless cert_info
+
+    Tempfile.open('cert') do |temp_cert|
+      temp_cert.write(cert_info)
+      temp_cert.rewind
+      fingerprint(temp_cert.path)
+    end
+  end
+
+  def directory_readable?(file)
+    File.directory?(file) && File.readable?(file)
+  end
+end

--- a/lib/puppet/type/nssdb_certificate.rb
+++ b/lib/puppet/type/nssdb_certificate.rb
@@ -1,0 +1,52 @@
+Puppet::Type.newtype(:nssdb_certificate) do
+  desc 'adds a certificate to an nssdb'
+
+  ensurable
+
+  def self.title_patterns
+    [ [ /(.+):(.+)/m, [ [:nssdb], [:cert_name] ] ] ]
+  end
+
+  newparam(:cert_name, :namevar => true) do
+    desc "The certificate name used to store inside the nssdb"
+  end
+
+  newparam(:nssdb, :namevar => true) do
+    desc "Path to the nssdb to use or create when importing the certificate"
+    isrequired
+  end
+
+  newproperty(:certificate) do
+    desc "Path to the certificate to add to the nssdb"
+
+    def fingerprint(file)
+      provider.fingerprint(file)
+    end
+
+    def should_to_s(newvalue)
+      self.class.format_value_for_display(fingerprint(newvalue))
+    end
+
+    def insync?(is)
+      is == fingerprint(should)
+    end
+  end
+
+  newparam(:private_key) do
+    desc "Path to the private key to add to the nssdb"
+  end
+
+  newparam(:trustargs) do
+    desc "Certificate trust flags for certificate inside the nssdb. Changing the trustargs on an existing certificate in the NSS database is not supported."
+    isrequired
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the nssdb password"
+    isrequired
+  end
+
+  autorequire(:file) do
+    [self[:password_file], self[:nssdb], self[:certificate], self[:private_key]]
+  end
+end

--- a/spec/acceptance/qpid_spec.rb
+++ b/spec/acceptance/qpid_spec.rb
@@ -63,6 +63,11 @@ describe 'certs' do
       its(:stdout) { should match(/\s*Subject: "CN=#{host_inventory['fqdn']},OU=SomeOrgUnit,O=pulp,ST=North Ca\n\s*rolina,C=US"/) }
       its(:stdout) { should match(/\s*Issuer: "CN=#{host_inventory['fqdn']},OU=SomeOrgUnit,O=Katello,L=Raleigh\n\s*,ST=North Carolina,C=US"/) }
     end
+
+    describe command("certutil -K -d #{nssdb_dir} -f #{nssdb_password_file} -n broker") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/rsa/) }
+    end
   end
 
   context 'updates certificate in nssdb if it changes' do

--- a/spec/classes/certs_qpid_spec.rb
+++ b/spec/classes/certs_qpid_spec.rb
@@ -27,27 +27,20 @@ describe 'certs::qpid' do
         end
 
         it do
-          is_expected.to contain_certs__ssltools__certutil('ca')
-            .with_nss_db_dir('/etc/pki/katello/nssdb')
-            .with_client_cert('/etc/pki/katello/certs/katello-default-ca.crt')
-            .that_subscribes_to('Pubkey[/etc/pki/katello/certs/katello-default-ca.crt]')
+          is_expected.to contain_nssdb_certificate('/etc/pki/katello/nssdb:ca')
+            .with_ensure('present')
+            .with_certificate('/etc/pki/katello/certs/katello-default-ca.crt')
+            .with_trustargs('TCu,Cu,Tuw')
+            .with_password_file('/etc/pki/katello/nssdb/nss_db_password-file')
         end
 
         it do
-          is_expected.to contain_certs__ssltools__certutil('broker')
-            .with_nss_db_dir('/etc/pki/katello/nssdb')
-            .with_client_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-            .that_subscribes_to('Pubkey[/etc/pki/katello/certs/foo.example.com-qpid-broker.crt]')
-        end
-
-        it do
-          is_expected.to contain_exec('generate-pfx-for-nss-db')
-            .with_command("openssl pkcs12 -in /etc/pki/katello/certs/foo.example.com-qpid-broker.crt -inkey /etc/pki/katello/private/foo.example.com-qpid-broker.key -export -out '/etc/pki/katello/foo.example.com-qpid-broker.pfx' -password 'file:/etc/pki/katello/nssdb/nss_db_password-file' -name 'broker'")
-        end
-
-        it do
-          is_expected.to contain_exec('add-private-key-to-nss-db')
-            .with_command("pk12util -i '/etc/pki/katello/foo.example.com-qpid-broker.pfx' -d '/etc/pki/katello/nssdb' -w '/etc/pki/katello/nssdb/nss_db_password-file' -k '/etc/pki/katello/nssdb/nss_db_password-file'")
+          is_expected.to contain_nssdb_certificate('/etc/pki/katello/nssdb:broker')
+            .with_ensure('present')
+            .with_certificate('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
+            .with_private_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
+            .with_trustargs(',,')
+            .with_password_file('/etc/pki/katello/nssdb/nss_db_password-file')
         end
       end
     end


### PR DESCRIPTION
This adds a type for managing NSS database certificates (and private keys)
within an NSS database. This new type reduces the number of intermediary
entities that have to be created, for example the pkcs12 export, and
reduces the overall Puppet code required. This type aims to provide
a clean interface to managing NSS database certificates and ensure
that the NSS database is in sync with the certificates being managed.

Requires: https://github.com/theforeman/puppet-certs/pull/326