### PR TITLE
Fixes #32506: Add keystore puppet provider

### DIFF
--- a/lib/puppet/provider/keystore/openssl.rb
+++ b/lib/puppet/provider/keystore/openssl.rb
@@ -1,0 +1,71 @@
+Puppet::Type.type(:keystore).provide(:openssl) do
+  commands :openssl => 'openssl'
+  commands :keytool => 'keytool'
+
+  def create
+    create_keystore
+  end
+
+  def destroy
+    File.delete(resource[:keystore])
+  end
+
+  def exists?
+    keystore_content
+  end
+
+  def certificate
+    keystore_fingerprint
+  end
+
+  def certificate=(value)
+    destroy unless keystore_content.nil?
+    create_keystore
+  end
+
+  def fingerprint(file)
+    return unless File.exist?(file)
+
+    openssl('x509', '-sha256', '-noout', '-fingerprint', '-in', file).strip.split('=')[1]
+  end
+
+  private
+
+  def create_keystore
+    openssl(
+      'pkcs12',
+      '-export',
+      '-in', resource[:certificate],
+      '-inkey', resource[:private_key],
+      '-out', resource[:keystore],
+      '-name', resource[:alias],
+      '-CAfile', resource[:ca_file],
+      '-password', "file:#{resource[:password_file]}"
+    )
+  end
+
+  def keystore_content
+    return unless file_readable?(resource[:keystore])
+    return unless file_readable?(resource[:password_file])
+
+    keytool(
+      '-list',
+      '-keystore', resource[:keystore],
+      '-storepass:file', resource[:password_file],
+      '-alias', resource[:alias],
+    )
+  rescue Puppet::ExecutionFailure => e
+    Puppet.debug("Failed to read keystore contents: #{e}")
+    # TODO: distinguish between invalid password, alias doesn't exist and others?
+    nil
+  end
+
+  def keystore_fingerprint
+    # TODO: include fingerprint type in the output?
+    keystore_content&.scan(/^Certificate fingerprint \(SHA-256\): (.+)$/)&.first&.first
+  end
+
+  def file_readable?(file)
+    File.file?(file) && File.readable?(file)
+  end
+end

--- a/lib/puppet/type/keystore.rb
+++ b/lib/puppet/type/keystore.rb
@@ -1,0 +1,62 @@
+Puppet::Type.newtype(:keystore) do
+  desc 'adds a certificate and private key to a pkcs12 keystore'
+
+  ensurable
+
+  def self.title_patterns
+    [ [ /(.+):(.+)/m, [ [:keystore], [:alias] ] ] ]
+  end
+
+  newparam(:alias, :namevar => true) do
+    desc "The certificate alias used to store inside the keystore"
+  end
+
+  newparam(:keystore, :namevar => true) do
+    desc "Path to the keystore to use or create when importing the certificate"
+    isrequired
+  end
+
+  newproperty(:certificate) do
+    desc "Path to the certificate to add to the keystore"
+
+    def fingerprint(file)
+      provider.fingerprint(file)
+    end
+
+    def should_to_s(newvalue)
+      self.class.format_value_for_display(fingerprint(newvalue))
+    end
+
+    def insync?(is)
+      is == fingerprint(should)
+    end
+  end
+
+  newparam(:private_key) do
+    desc "Path to file containing the keystore password"
+    isrequired
+  end
+
+  newparam(:ca_file) do
+    desc "Path to the CA certificate"
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the keystore password"
+    isrequired
+  end
+
+  autorequire(:file) do
+    [
+      self[:password_file],
+      File.dirname(self[:keystore]),
+      self[:certificate],
+      self[:private_key],
+      self[:ca_file]
+    ]
+  end
+
+  autonotify(:file) do
+    [self[:keystore]]
+  end
+end

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -206,4 +206,47 @@ describe 'certs' do
       expect(truststore_output.output.strip).not_to include(initial_fingerprint)
     end
   end
+
+  context 'updates keystore if the certificate changes' do
+    let(:pp) do
+      <<-EOS
+      user { 'tomcat':
+        ensure => present,
+      }
+
+      ['/usr/share/tomcat/conf', '/etc/candlepin/certs'].each |$dir| {
+        exec { "mkdir -p ${dir}":
+          creates => $dir,
+          path    => ['/bin', '/usr/bin'],
+        }
+      }
+
+      package { 'java-1.8.0-openjdk-headless':
+        ensure => installed,
+      }
+
+      include certs::candlepin
+      EOS
+    end
+
+    it "checks that the fingerprint matches" do
+      apply_manifest(pp, catch_failures: true)
+
+      initial_fingerprint_output = on default, 'openssl x509 -noout -fingerprint -sha256 -in /etc/pki/katello/certs/katello-tomcat.crt'
+      initial_fingerprint = initial_fingerprint_output.output.strip.split('=').last
+      initial_keystore_output = on default, "keytool -list -keystore /etc/candlepin/certs/keystore -storepass $(cat #{keystore_password_file})"
+      expect(initial_keystore_output.output.strip).to include(initial_fingerprint)
+
+      on default, "rm -rf /root/ssl-build/#{host_inventory['fqdn']}"
+      apply_manifest(pp, catch_failures: true)
+
+      fingerprint_output = on default, 'openssl x509 -noout -fingerprint -sha256 -in /etc/pki/katello/certs/katello-tomcat.crt'
+      fingerprint = fingerprint_output.output.strip.split('=').last
+      keystore_output = on default, "keytool -list -keystore /etc/candlepin/certs/keystore -storepass $(cat #{keystore_password_file})"
+
+      expect(keystore_output.output.strip).to include(fingerprint)
+      expect(fingerprint).not_to equal(initial_fingerprint)
+      expect(keystore_output.output.strip).not_to include(initial_fingerprint)
+    end
+  end
 end


### PR DESCRIPTION
Add a provider and type to create and manage a keystore for use
by Candlepin. Adds a test to ensure that the keystore gets updated
if the certificate changes.

As part of this change I inspected and tested the viability of other options (e.g. puppetlabs-java_ks, camptocamp/puppet-openssl) and none of them met our needs completely. 