### PR TITLE
Make pulp_client ensurable to allow removal

### DIFF
--- a/manifests/keypair.pp
+++ b/manifests/keypair.pp
@@ -1,7 +1,9 @@
+# @api private
 define certs::keypair (
   $key_pair,
   $key_file,
   $cert_file,
+  Enum['present', 'absent'] $ensure = 'present',
   $manage_key  = false,
   $key_owner   = undef,
   $key_group   = undef,
@@ -16,18 +18,22 @@ define certs::keypair (
 ) {
   $key_pair ~>
   privkey { $key_file:
+    ensure        => $ensure,
     key_pair      => $key_pair,
     unprotect     => $unprotect,
     password_file => $password_file,
   } ~>
   pubkey { $cert_file:
+    ensure   => $ensure,
     key_pair => $key_pair,
     strip    => $strip,
   }
 
+  $file_ensure = bool2str($ensure == 'present', 'file', 'absent')
+
   if $manage_key {
     file { $key_file:
-      ensure  => file,
+      ensure  => $file_ensure,
       owner   => $key_owner,
       group   => $key_group,
       mode    => $key_mode,
@@ -37,7 +43,7 @@ define certs::keypair (
 
   if $manage_cert {
     file { $cert_file:
-      ensure  => file,
+      ensure  => $file_ensure,
       owner   => $cert_owner,
       group   => $cert_group,
       mode    => $cert_mode,

--- a/manifests/pulp_client.pp
+++ b/manifests/pulp_client.pp
@@ -1,5 +1,6 @@
 # Pulp Client Certs
 class certs::pulp_client (
+  Enum['present', 'absent'] $ensure = 'present',
   $hostname    = $certs::node_fqdn,
   $cname       = $certs::cname,
   $generate    = $certs::generate,
@@ -23,6 +24,7 @@ class certs::pulp_client (
   $ssl_ca_cert      = $ca_cert
 
   cert { $client_cert_name:
+    ensure        => $ensure,
     hostname      => $hostname,
     cname         => $cname,
     common_name   => $common_name,
@@ -42,6 +44,7 @@ class certs::pulp_client (
 
   if $deploy {
     certs::keypair { 'pulp_client':
+      ensure     => $ensure,
       key_pair   => Cert[$client_cert_name],
       key_file   => $client_key,
       manage_key => true,

--- a/spec/acceptance/pulp_client_spec.rb
+++ b/spec/acceptance/pulp_client_spec.rb
@@ -1,0 +1,25 @@
+describe 'certs::pulp_client', order: :defined do
+  context 'installation' do
+    let(:pp) do
+      <<~PUPPET
+      class { 'certs::pulp_client':
+        ensure => present,
+      }
+      PUPPET
+    end
+
+    it_behaves_like 'a idempotent resource'
+  end
+
+  context 'removal' do
+    let(:pp) do
+      <<~PUPPET
+      class { 'certs::pulp_client':
+        ensure => absent,
+      }
+      PUPPET
+    end
+
+    it_behaves_like 'a idempotent resource'
+  end
+end


### PR DESCRIPTION
Untested, but as a reference response to https://github.com/theforeman/puppet-certs/pull/324. Using this to test since on my laptop I can't run Puppet right now (Ruby 3 in Fedora 34). Will pull it on my Fedora 33 desktop.