### PR TITLE
Fixes #32506: Add keystore puppet provider type

### DIFF
--- a/lib/puppet/provider/keystore/keytool.rb
+++ b/lib/puppet/provider/keystore/keytool.rb
@@ -1,0 +1,51 @@
+Puppet::Type.type(:keystore).provide(:keytool) do
+  commands :keytool => 'keytool'
+
+  def create
+    generate_keystore
+  end
+
+  def destroy
+    delete_keystore
+  end
+
+  def exists?
+    File.exist?(resource[:keystore])
+  end
+
+  private
+
+  def generate_keystore
+    temp_alias = 'temporary-entry'
+
+    begin
+      keytool(
+        '-genkey',
+        '-storetype', 'pkcs12',
+        '-keystore', resource[:keystore],
+        '-storepass:file', resource[:password_file],
+        '-alias', temp_alias,
+        '-dname', "CN=#{temp_alias}"
+      )
+    rescue Puppet::ExecutionFailure => e
+      Puppet.error("Failed to generate new keystore with temporary entry: #{e}")
+      return nil
+    end
+
+    begin
+      keytool(
+        '-delete',
+        '-keystore', resource[:keystore],
+        '-storepass:file', resource[:password_file],
+        '-alias', temp_alias
+      )
+    rescue Puppet::ExecutionFailure => e
+      Puppet.error("Failed to delete temporary entry when generating empty keystore: #{e}")
+      return nil
+    end
+  end
+
+  def delete_keystore
+    File.rm(resource[:keystore])
+  end
+end

--- a/lib/puppet/type/keystore.rb
+++ b/lib/puppet/type/keystore.rb
@@ -1,0 +1,55 @@
+Puppet::Type.newtype(:keystore) do
+  desc 'generates an empty pkcs12 keystore'
+
+  ensurable
+
+  newparam(:keystore, :namevar => true) do
+    desc "Path to the keystore"
+    isrequired
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the keystore password"
+    isrequired
+  end
+
+  newparam(:owner, parent: Puppet::Type::File::Owner) do
+    desc "Specifies the owner of the keystore. Valid options: a string containing a username or integer containing a uid."
+  end
+
+  newparam(:group, parent: Puppet::Type::File::Group) do
+    desc "Specifies a permissions group for the keystore. Valid options: a string containing a group name or integer containing a gid."
+  end
+
+  newparam(:mode, parent: Puppet::Type::File::Mode) do
+    desc "Specifies the permissions mode of the keystore. Valid options: a string containing a permission mode value in octal notation."
+  end
+
+  autorequire(:file) do
+    [self[:password_file]]
+  end
+
+  def generate
+    file_opts = {
+      ensure: (self[:ensure] == :absent) ? :absent : :file,
+      path: self[:keystore],
+    }
+
+    [:owner,
+     :group,
+     :mode].each do |param|
+      file_opts[param] = self[param] unless self[param].nil?
+    end
+
+    metaparams = Puppet::Type.metaparams
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    metaparams.reject! { |param| excluded_metaparams.include? param }
+
+    metaparams.each do |metaparam|
+      file_opts[metaparam] = self[metaparam] unless self[metaparam].nil?
+    end
+
+    [Puppet::Type.type(:file).new(file_opts)]
+  end
+end

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -110,12 +110,7 @@ class certs::candlepin (
       unless    => "keytool -list -keystore ${keystore} -storepass:file ${keystore_password_path} -alias tomcat | grep $(openssl x509 -noout -fingerprint -sha256 -in ${tomcat_cert} | cut -d '=' -f 2)",
       logoutput => 'on_failure',
       path      => ['/bin/', '/usr/bin'],
-    } ~>
-    file { $keystore:
-      ensure => file,
-      owner  => 'root',
-      group  => $group,
-      mode   => '0640',
+      require   => Keystore[$keystore],
     } ~>
     certs::keypair { 'candlepin':
       key_pair    => Cert[$java_client_cert_name],
@@ -129,6 +124,14 @@ class certs::candlepin (
       key_owner   => $user,
       key_group   => $client_keypair_group,
       key_mode    => '0440',
+    }
+
+    keystore { $keystore:
+      ensure        => present,
+      password_file => $keystore_password_path,
+      owner         => 'root',
+      group         => $group,
+      mode          => '0640',
     }
 
     file { $truststore_password_path:


### PR DESCRIPTION
This allows creating and managing a PKCS12 based keystore that
is initially empty. This allows managing the permissions and ownership
of the keystore separately from any certificates within it.

This is an alternative to what was discussed here -- https://github.com/theforeman/puppet-certs/pull/329#discussion_r629315815

The follow up would be then to introduce a type `keystore_certificate` that would roughly look like:

```
    keystore_certificate { "${keystore}:tomcat":
      ensure          => 'present',
      certificate     => $tomcat_cert,
      private_key  => $tomcat_key,
      ca_file           => $ca_cert,
      password_file => $keystore_password_path,
    }
```

Where keystore_certificate would have an autorequires on `Keystore[$keystore]` effectively. While I like the discussed all in one declaration:

```
keystore { $keystore:
  ensure        => present,
  password_file => $keystore_password_path,
  certificates  => [
    {
      alias => $alias,
      certificate => $ca_cert,
    },
    {
      alias => $artemis_alias,
      certificate => $client_cert,
      private_key => $client_key,
    },
  ],
}
```

My guy feeling is that having broken out, smaller dedicated resources will be easier to manage.