### PR TITLE
Fixes #32637: Add truststore type and provider 

### DIFF
--- a/lib/puppet/provider/keystore/keytool.rb
+++ b/lib/puppet/provider/keystore/keytool.rb
@@ -1,51 +1,7 @@
+require 'puppet_x/certs/provider/keystore'
+
 Puppet::Type.type(:keystore).provide(:keytool) do
   commands :keytool => 'keytool'
 
-  def create
-    generate_keystore
-  end
-
-  def destroy
-    delete_keystore
-  end
-
-  def exists?
-    File.exist?(resource[:keystore])
-  end
-
-  private
-
-  def generate_keystore
-    temp_alias = 'temporary-entry'
-
-    begin
-      keytool(
-        '-genkey',
-        '-storetype', 'pkcs12',
-        '-keystore', resource[:keystore],
-        '-storepass:file', resource[:password_file],
-        '-alias', temp_alias,
-        '-dname', "CN=#{temp_alias}"
-      )
-    rescue Puppet::ExecutionFailure => e
-      Puppet.err("Failed to generate new keystore with temporary entry: #{e}")
-      return nil
-    end
-
-    begin
-      keytool(
-        '-delete',
-        '-keystore', resource[:keystore],
-        '-storepass:file', resource[:password_file],
-        '-alias', temp_alias
-      )
-    rescue Puppet::ExecutionFailure => e
-      Puppet.err("Failed to delete temporary entry when generating empty keystore: #{e}")
-      return nil
-    end
-  end
-
-  def delete_keystore
-    File.rm(resource[:keystore])
-  end
+  include Puppet_X::Certs::Provider::Keystore
 end

--- a/lib/puppet/provider/truststore/keytool.rb
+++ b/lib/puppet/provider/truststore/keytool.rb
@@ -1,0 +1,15 @@
+require 'puppet_x/certs/provider/keystore'
+
+Puppet::Type.type(:truststore).provide(:keytool) do
+  commands :keytool => 'keytool'
+
+  include Puppet_X::Certs::Provider::Keystore
+
+  def store
+    resource[:truststore]
+  end
+
+  def type
+    'truststore'
+  end
+end

--- a/lib/puppet/type/truststore.rb
+++ b/lib/puppet/type/truststore.rb
@@ -1,0 +1,54 @@
+Puppet::Type.newtype(:truststore) do
+  desc 'Generates an empty pkcs12 truststore'
+
+  ensurable
+
+  newparam(:truststore, :namevar => true) do
+    desc "Path to the truststore"
+    isrequired
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the truststore password"
+    isrequired
+  end
+
+  newparam(:owner, parent: Puppet::Type::File::Owner) do
+    desc "Specifies the owner of the truststore. Valid options: a string containing a username or integer containing a uid."
+  end
+
+  newparam(:group, parent: Puppet::Type::File::Group) do
+    desc "Specifies a permissions group for the truststore. Valid options: a string containing a group name or integer containing a gid."
+  end
+
+  newparam(:mode, parent: Puppet::Type::File::Mode) do
+    desc "Specifies the permissions mode of the truststore. Valid options: a string containing a permission mode value in octal notation."
+  end
+
+  autorequire(:file) do
+    [self[:password_file]]
+  end
+
+  def generate
+    file_opts = {
+      ensure: (self[:ensure] == :absent) ? :absent : :file,
+      path: self[:truststore],
+    }
+
+    [:owner,
+     :group,
+     :mode].each do |param|
+      file_opts[param] = self[param] unless self[param].nil?
+    end
+
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
+    end
+
+    [Puppet::Type.type(:file).new(file_opts)]
+  end
+end

--- a/lib/puppet_x/certs/provider/keystore.rb
+++ b/lib/puppet_x/certs/provider/keystore.rb
@@ -1,0 +1,61 @@
+module Puppet_X
+  module Certs
+    module Provider
+      module Keystore
+        def create
+          generate_keystore
+        end
+
+        def destroy
+          delete_keystore
+        end
+
+        def exists?
+          File.exist?(store)
+        end
+
+        def store
+          resource[:keystore]
+        end
+
+        def type
+          'keystore'
+        end
+
+        def generate_keystore
+          temp_alias = 'temporary-entry'
+
+          begin
+            keytool(
+              '-genkey',
+              '-storetype', 'pkcs12',
+              '-keystore', store,
+              '-storepass:file', resource[:password_file],
+              '-alias', temp_alias,
+              '-dname', "CN=#{temp_alias}"
+            )
+          rescue Puppet::ExecutionFailure => e
+            Puppet.err("Failed to generate new #{type} with temporary entry: #{e}")
+            return nil
+          end
+
+          begin
+            keytool(
+              '-delete',
+              '-keystore', store,
+              '-storepass:file', resource[:password_file],
+              '-alias', temp_alias
+            )
+          rescue Puppet::ExecutionFailure => e
+            Puppet.err("Failed to delete temporary entry when generating empty #{type}: #{e}")
+            return nil
+          end
+        end
+
+        def delete_keystore
+          File.rm(store)
+        end
+      end
+    end
+  end
+end

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -143,6 +143,14 @@ class certs::candlepin (
       show_diff => false,
     }
 
+    truststore { $truststore:
+      ensure        => present,
+      password_file => $truststore_password_path,
+      owner         => 'root',
+      group         => $group,
+      mode          => '0640',
+    }
+
     truststore_certificate { "${truststore}:${alias}":
       ensure        => present,
       password_file => $truststore_password_path,
@@ -153,13 +161,6 @@ class certs::candlepin (
       ensure        => present,
       password_file => $truststore_password_path,
       certificate   => $client_cert,
-    }
-
-    file { $truststore:
-      ensure => file,
-      owner  => 'root',
-      group  => $group,
-      mode   => '0640',
     }
   }
 }

--- a/spec/acceptance/truststore_spec.rb
+++ b/spec/acceptance/truststore_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper_acceptance'
+
+describe 'certs' do
+  context 'with truststore type' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        $truststore_password_file = '/etc/pki/truststore_password-file'
+
+        package { 'java-11-openjdk-headless':
+          ensure => installed,
+        }
+
+        file { $truststore_password_file:
+          ensure    => file,
+          content   => 'testpassword',
+          owner     => 'root',
+          group     => 'root',
+          mode      => '0440',
+          show_diff => false,
+        }
+
+        truststore { "/etc/pki/truststore":
+          ensure        => present,
+          password_file => $truststore_password_file,
+          owner         => 'root',
+          group         => 'root',
+          mode          => '0640',
+        }
+        PUPPET
+      end
+    end
+
+    describe file('/etc/pki/truststore') do
+      it { should be_file }
+      it { should be_mode 640 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
+
+    describe command("keytool -list -keystore /etc/pki/truststore -storepass:file /etc/pki/truststore_password-file") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match(/^Keystore type: PKCS12$/i) }
+      its(:stdout) { should match(/^Your keystore contains 0 entries$/) }
+    end
+  end
+end


### PR DESCRIPTION
Builds on #334 re-factoring what is present there into a common module.

I did not want to create one giant PR with all of these types but rather a set of progressive PRs that build one on each other to make it easier to review, discuss and ultimately to merge in smaller logical pieces.