### PR TITLE
Refs #32506 - Avoid in place modification of array

### DIFF
--- a/lib/puppet/type/keystore.rb
+++ b/lib/puppet/type/keystore.rb
@@ -41,13 +41,12 @@ Puppet::Type.newtype(:keystore) do
       file_opts[param] = self[param] unless self[param].nil?
     end
 
-    metaparams = Puppet::Type.metaparams
     excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
 
-    metaparams.reject! { |param| excluded_metaparams.include? param }
-
-    metaparams.each do |metaparam|
-      file_opts[metaparam] = self[metaparam] unless self[metaparam].nil?
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
     end
 
     [Puppet::Type.type(:file).new(file_opts)]


### PR DESCRIPTION
In 47db06c5fd01fba4e06af5325470c8c146074bba a new keystore provider was added. This modifies metaparams in place which can have side effects. This patch changes it to not need it.

Fixes: 47db06c5fd01fba4e06af5325470c8c146074bba