### PR TITLE
Declare the build directory for all certificate creation

### DIFF
--- a/lib/puppet/provider/ca/katello_ssl_tool.rb
+++ b/lib/puppet/provider/ca/katello_ssl_tool.rb
@@ -10,12 +10,14 @@ Puppet::Type.type(:ca).provide(:katello_ssl_tool, :parent => Puppet::Provider::K
       FileUtils.mkdir_p(build_path)
       FileUtils.cp(existing_pubkey, build_path(File.basename(pubkey)))
       katello_ssl_tool('--gen-ca',
+                       '--dir', resource[:build_dir],
                        '--ca-cert-dir', target_path('certs'),
                        '--ca-cert', File.basename(pubkey),
                        '--ca-cert-rpm', rpmfile_base_name,
                        '--rpm-only')
     else
       katello_ssl_tool('--gen-ca',
+                       '--dir', resource[:build_dir],
                        '-p', "file:#{resource[:password_file]}",
                        '--force',
                        '--ca-cert-dir', target_path('certs'),

--- a/lib/puppet/provider/cert/katello_ssl_tool.rb
+++ b/lib/puppet/provider/cert/katello_ssl_tool.rb
@@ -5,6 +5,7 @@ Puppet::Type.type(:cert).provide(:katello_ssl_tool, :parent => Puppet::Provider:
 
   def generate!
     args = [ "--gen-#{resource[:purpose]}",
+              '--dir', resource[:build_dir],
               '--set-hostname', resource[:hostname],
               '--server-cert', File.basename(pubkey),
               '--server-cert-req', File.basename(req_file),

--- a/lib/puppet_x/certs/common.rb
+++ b/lib/puppet_x/certs/common.rb
@@ -42,6 +42,18 @@ module PuppetX
 
         newparam(:password_file)
 
+        newparam(:build_dir) do
+          defaultto('/root/ssl-build')
+
+          validate do |value|
+            if value.empty?
+              raise ArgumentError, "build_dir cannot be empty"
+            else
+              super(value)
+            end
+          end
+        end
+
         newparam(:ca) do
           validate do |value|
             ca_resource = resource.catalog.resource(value.to_s)

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -36,6 +36,7 @@ class certs::apache (
       custom_pubkey  => $server_cert,
       custom_privkey => $server_key,
       custom_req     => $server_cert_req,
+      build_dir      => $certs::ssl_build_dir,
     }
   } else {
     cert { $apache_cert_name:
@@ -53,6 +54,7 @@ class certs::apache (
       regenerate    => $regenerate,
       deploy        => $deploy,
       password_file => $ca_key_password_file,
+      build_dir     => $certs::ssl_build_dir,
     }
   }
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -43,6 +43,7 @@ class certs::ca (
     generate      => $generate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
   $default_ca = Ca[$default_ca_name]
 
@@ -52,13 +53,15 @@ class certs::ca (
       generate      => $generate,
       deploy        => $deploy,
       custom_pubkey => $certs::server_ca_cert,
+      build_dir     => $certs::ssl_build_dir,
     }
   } else {
     ca { $server_ca_name:
-      ensure   => present,
-      generate => $generate,
-      deploy   => $deploy,
-      ca       => $default_ca,
+      ensure    => present,
+      generate  => $generate,
+      deploy    => $deploy,
+      ca        => $default_ca,
+      build_dir => $certs::ssl_build_dir,
     }
   }
   $server_ca = Ca[$server_ca_name]

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -43,6 +43,7 @@ class certs::candlepin (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   $tomcat_cert_name = "${hostname}-tomcat"
@@ -64,6 +65,7 @@ class certs::candlepin (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   $keystore_password = extlib::cache_data('foreman_cache_data', $keystore_password_file, extlib::random_password(32))

--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -35,6 +35,7 @@ class certs::foreman (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -48,6 +48,7 @@ class certs::foreman_proxy (
       custom_pubkey  => $server_cert,
       custom_privkey => $server_key,
       custom_req     => $server_cert_req,
+      build_dir      => $certs::ssl_build_dir,
     }
   } else {
     # cert for ssl of foreman-proxy
@@ -66,6 +67,7 @@ class certs::foreman_proxy (
       regenerate    => $regenerate,
       deploy        => $deploy,
       password_file => $ca_key_password_file,
+      build_dir     => $certs::ssl_build_dir,
     }
   }
 
@@ -85,6 +87,7 @@ class certs::foreman_proxy (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {

--- a/manifests/pulp_client.pp
+++ b/manifests/pulp_client.pp
@@ -38,6 +38,7 @@ class certs::pulp_client (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -39,6 +39,7 @@ class certs::puppet (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -35,6 +35,7 @@ class certs::qpid (
     regenerate    => $regenerate,
     deploy        => $deploy,
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {

--- a/manifests/qpid_router/client.pp
+++ b/manifests/qpid_router/client.pp
@@ -37,6 +37,7 @@ class certs::qpid_router::client (
     deploy        => $deploy,
     purpose       => 'client',
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {

--- a/manifests/qpid_router/server.pp
+++ b/manifests/qpid_router/server.pp
@@ -37,6 +37,7 @@ class certs::qpid_router::server (
     deploy        => $deploy,
     purpose       => 'server',
     password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
   }
 
   if $deploy {


### PR DESCRIPTION
The build directory for certificates is declared as a parameter
but has no direct link to what the underlying tool would use
as the build directory. This change links the two up so that
there is no discrepancy and enables relying on the build directory
and paths within it.