### PR TITLE
Deploy managed certificate and key from build directory

### DIFF
--- a/lib/puppet/provider/certificate_file/certificate_file.rb
+++ b/lib/puppet/provider/certificate_file/certificate_file.rb
@@ -1,0 +1,3 @@
+Puppet::Type.type(:certificate_file).provide(:openssl) do
+  commands :openssl => 'openssl'
+end

--- a/lib/puppet/provider/certificate_file/certificate_file.rb
+++ b/lib/puppet/provider/certificate_file/certificate_file.rb
@@ -1,3 +1,24 @@
 Puppet::Type.type(:certificate_file).provide(:openssl) do
   commands :openssl => 'openssl'
+
+  def source_cert
+    if valid?(resource[:source_cert])
+      resource[:source_cert]
+    else
+      raise ArgumentError, "Source certificate is not a valid x509 certificate"
+    end
+  end
+
+  def valid?(certificate)
+    File.exist?(certificate)
+    pem_format?(certificate)
+  end
+
+  def pem_format?(certificate)
+    openssl(
+      'x509',
+      '-inform', 'PEM',
+      '-in', certificate
+    )
+  end
 end

--- a/lib/puppet/type/certificate_file.rb
+++ b/lib/puppet/type/certificate_file.rb
@@ -1,0 +1,48 @@
+Puppet::Type.newtype(:certificate_file) do
+  desc 'Manages an x509 certificate file from a source certificate'
+
+  ensurable
+
+  newparam(:path, :namevar => true) do
+    desc "Path the certificate will be copied to."
+  end
+
+  newparam(:owner, parent: Puppet::Type::File::Owner) do
+    desc "Specifies the owner of the truststore. Valid options: a string containing a username or integer containing a uid."
+  end
+
+  newparam(:group, parent: Puppet::Type::File::Group) do
+    desc "Specifies a permissions group for the truststore. Valid options: a string containing a group name or integer containing a gid."
+  end
+
+  newparam(:mode, parent: Puppet::Type::File::Mode) do
+    desc "Specifies the permissions mode of the truststore. Valid options: a string containing a permission mode value in octal notation."
+  end
+
+  newparam(:source, parent: Puppet::Type::File::ParameterSource) do
+    desc "Specifies the source certificate that will be copied to the declared location."
+  end
+
+  def generate
+    file_opts = {
+      ensure: (self[:ensure] == :absent) ? :absent : :file,
+    }
+
+    [:owner,
+     :group,
+     :source,
+     :mode].each do |param|
+      file_opts[param] = self[param] unless self[param].nil?
+    end
+
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
+    end
+
+    [Puppet::Type.type(:file).new(file_opts)]
+  end
+end

--- a/lib/puppet/type/certificate_file.rb
+++ b/lib/puppet/type/certificate_file.rb
@@ -3,6 +3,10 @@ Puppet::Type.newtype(:certificate_file) do
 
   ensurable
 
+  def exists?
+    self[:ensure] == :present
+  end
+
   newparam(:path, :namevar => true) do
     desc "Path the certificate will be copied to."
   end
@@ -19,19 +23,24 @@ Puppet::Type.newtype(:certificate_file) do
     desc "Specifies the permissions mode of the truststore. Valid options: a string containing a permission mode value in octal notation."
   end
 
-  newparam(:source, parent: Puppet::Type::File::ParameterSource) do
+  newproperty(:source_cert) do
     desc "Specifies the source certificate that will be copied to the declared location."
   end
 
   def generate
     file_opts = {
       ensure: (self[:ensure] == :absent) ? :absent : :file,
+      source: self[:source_cert],
     }
 
-    [:owner,
-     :group,
-     :source,
-     :mode].each do |param|
+    params = [
+      :path,
+      :owner,
+      :group,
+      :mode
+    ]
+
+    params.each do |param|
       file_opts[param] = self[param] unless self[param].nil?
     end
 

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -31,7 +31,7 @@ class certs::apache (
       hostname       => $hostname,
       cname          => $cname,
       generate       => $generate,
-      deploy         => false,
+      deploy         => $deploy,
       regenerate     => $regenerate,
       custom_pubkey  => $server_cert,
       custom_privkey => $server_key,
@@ -52,29 +52,24 @@ class certs::apache (
       ca            => $default_ca,
       generate      => $generate,
       regenerate    => $regenerate,
-      deploy        => false,
+      deploy        => $deploy,
       password_file => $ca_key_password_file,
       build_dir     => $certs::ssl_build_dir,
     }
   }
 
   if $deploy {
-    file { $apache_key:
-      ensure  => file,
-      source  => "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}.key",
-      owner   => 'root',
-      group   => $group,
-      mode    => '0440',
-      require => Cert[$apache_cert_name],
-    }
-
-    file { $apache_cert:
-      ensure  => file,
-      source  => "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}.crt",
-      owner   => 'root',
-      group   => $group,
-      mode    => '0640',
-      require => Cert[$apache_cert_name],
+    certs::key_pair { $apache_cert_name:
+      source_dir => "${certs::ssl_build_dir}/${hostname}",
+      key_file   => $apache_key,
+      key_owner  => 'root',
+      key_group  => $group,
+      key_mode   => '0440',
+      cert_file  => $apache_cert,
+      cert_owner => 'root',
+      cert_group => $group,
+      cert_mode  => '0440',
+      require    => Cert[$apache_cert_name],
     }
   }
 }

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -31,7 +31,7 @@ class certs::apache (
       hostname       => $hostname,
       cname          => $cname,
       generate       => $generate,
-      deploy         => $deploy,
+      deploy         => false,
       regenerate     => $regenerate,
       custom_pubkey  => $server_cert,
       custom_privkey => $server_key,
@@ -52,21 +52,29 @@ class certs::apache (
       ca            => $default_ca,
       generate      => $generate,
       regenerate    => $regenerate,
-      deploy        => $deploy,
+      deploy        => false,
       password_file => $ca_key_password_file,
       build_dir     => $certs::ssl_build_dir,
     }
   }
 
   if $deploy {
-    certs::keypair { 'apache':
-      key_pair   => Cert[$apache_cert_name],
-      key_file   => $apache_key,
-      manage_key => true,
-      key_owner  => 'root',
-      key_group  => $group,
-      key_mode   => '0440',
-      cert_file  => $apache_cert,
+    file { $apache_key:
+      ensure  => file,
+      source  => "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}.key",
+      owner   => 'root',
+      group   => $group,
+      mode    => '0440',
+      require => Cert[$apache_cert_name],
+    }
+
+    file { $apache_cert:
+      ensure  => file,
+      source  => "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}.crt",
+      owner   => 'root',
+      group   => $group,
+      mode    => '0640',
+      require => Cert[$apache_cert_name],
     }
   }
 }

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -20,10 +20,9 @@ class certs::apache (
   $group                = $certs::group,
 ) inherits certs {
 
-  $apache_cert_name = "${hostname}-apache"
   $apache_cert = "${pki_dir}/certs/katello-apache.crt"
   $apache_key  = "${pki_dir}/private/katello-apache.key"
-  $apache_ca_cert = $certs::katello_server_ca_cert
+  $apache_cert_name = "${hostname}-apache"
 
   if $server_cert {
     cert { $apache_cert_name:
@@ -31,7 +30,7 @@ class certs::apache (
       hostname       => $hostname,
       cname          => $cname,
       generate       => $generate,
-      deploy         => $deploy,
+      deploy         => false,
       regenerate     => $regenerate,
       custom_pubkey  => $server_cert,
       custom_privkey => $server_key,
@@ -52,7 +51,7 @@ class certs::apache (
       ca            => $default_ca,
       generate      => $generate,
       regenerate    => $regenerate,
-      deploy        => $deploy,
+      deploy        => false,
       password_file => $ca_key_password_file,
       build_dir     => $certs::ssl_build_dir,
     }

--- a/manifests/key_pair.pp
+++ b/manifests/key_pair.pp
@@ -1,0 +1,32 @@
+define certs::key_pair (
+  $source_dir,
+  $key_file,
+  $cert_file,
+  $key_owner   = undef,
+  $key_group   = undef,
+  $key_mode    = undef,
+  $cert_owner  = undef,
+  $cert_group  = undef,
+  $cert_mode   = undef,
+  $require     = undef,
+) {
+
+  file { $key_file:
+    ensure  => file,
+    source  => "${source_dir}/${title}.key",
+    owner   => $key_owner,
+    group   => $key_group,
+    mode    => $key_mode,
+    require => $require,
+  }
+
+  file { $cert_file:
+    ensure  => file,
+    source  => "${source_dir}/${title}.crt",
+    owner   => $cert_owner,
+    group   => $cert_group,
+    mode    => $cert_mode,
+    require => $require,
+  }
+
+}

--- a/manifests/key_pair.pp
+++ b/manifests/key_pair.pp
@@ -8,7 +8,6 @@ define certs::key_pair (
   $cert_owner  = undef,
   $cert_group  = undef,
   $cert_mode   = undef,
-  $require     = undef,
 ) {
 
   file { $key_file:
@@ -17,16 +16,14 @@ define certs::key_pair (
     owner   => $key_owner,
     group   => $key_group,
     mode    => $key_mode,
-    require => $require,
   }
 
-  file { $cert_file:
+  certificate_file { $cert_file:
     ensure  => file,
     source  => "${source_dir}/${title}.crt",
     owner   => $cert_owner,
     group   => $cert_group,
     mode    => $cert_mode,
-    require => $require,
   }
 
 }

--- a/manifests/key_pair.pp
+++ b/manifests/key_pair.pp
@@ -19,11 +19,11 @@ define certs::key_pair (
   }
 
   certificate_file { $cert_file:
-    ensure  => file,
-    source  => "${source_dir}/${title}.crt",
-    owner   => $cert_owner,
-    group   => $cert_group,
-    mode    => $cert_mode,
+    ensure           => present,
+    source_cert      => "${source_dir}/${title}.crt",
+    owner            => $cert_owner,
+    group            => $cert_group,
+    mode             => $cert_mode,
   }
 
 }


### PR DESCRIPTION
This change no longer installs the RPMs that are generated when creating
certificates. Instead, the certificates that are deployed are pulled
from their locations generated on disk by the katello-ssl-tool. This
removes a layer of indirection and simplifies the creation and management
of the certificates.

With the RPMs present, a given key-pair would be created in the
ssl_build_dir, then deployed to /etc/pki/katello-certs-tools and then
copied and managed somewhere else on disk, often /etc/pki/katello.