### PR TITLE
Mark compatible with puppet/trusted_ca 4.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet-trusted_ca",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
This major version only dropped some support so there's no API compatibility changes.