### PR TITLE
Remove dependency on trusted_ca

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,3 @@ fixtures:
     concat:            "https://github.com/puppetlabs/puppetlabs-concat"
     extlib:            "https://github.com/voxpupuli/puppet-extlib"
     stdlib:            "https://github.com/puppetlabs/puppetlabs-stdlib"
-    trusted_ca:        "https://github.com/voxpupuli/puppet-trusted_ca"

--- a/metadata.json
+++ b/metadata.json
@@ -9,10 +9,6 @@
   "issues_url": "https://projects.theforeman.org/projects/katello/issues",
   "dependencies": [
     {
-      "name": "puppet-trusted_ca",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
-    },
-    {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.25.0 < 8.0.0"
     },


### PR DESCRIPTION
953261ffd2eb52b7176ab365fb0c4e9245435d99 removed the last use of trusted_ca so this module no longer depends on it.

Marking as an enhancement since this should result in a minor version bump. It was noted that theforeman/foreman_proxy_content didn't add the dependency explicitly. We do bump patch versions in stable releases and that can break.

Fixes: 953261ffd2eb52b7176ab365fb0c4e9245435d99