### PR TITLE
Include certs directory tarball

### DIFF
--- a/manifests/tar_create.pp
+++ b/manifests/tar_create.pp
@@ -12,9 +12,17 @@ define certs::tar_create(
   $path               = $title,
   $foreman_proxy_fqdn = $certs::foreman_proxy_content::foreman_proxy_fqdn,
 ) {
+
+  $ca_rpms = 'ssl-build/*.noarch.rpm'
+  $ca_certificates = 'ssl-build/*.crt'
+
+  $foreman_proxy_certificate_rpms = "ssl-build/${foreman_proxy_fqdn}/*.noarch.rpm"
+  $foreman_proxy_certificates = "ssl-build/${foreman_proxy_fqdn}/*.crt"
+  $foreman_proxy_keys = "ssl-build/${foreman_proxy_fqdn}/*.key"
+
   exec { "generate ${path}":
     cwd     => '/root',
     path    => ['/usr/bin', '/bin'],
-    command => "tar -czf ${path} ssl-build/*.noarch.rpm ssl-build/${foreman_proxy_fqdn}/*.noarch.rpm",
+    command => "tar -czf ${path} ${ca_rpms} ${ca_certificates} ${foreman_proxy_certificate_rpms} ${foreman_proxy_certificates} ${foreman_proxy_keys}",
   }
 }

--- a/spec/acceptance/certs_tar_extract_spec.rb
+++ b/spec/acceptance/certs_tar_extract_spec.rb
@@ -52,7 +52,34 @@ describe 'certs with tar archive' do
     it { should have_matching_certificate('/etc/pki/katello/certs/katello-apache.crt') }
   end
 
+  describe x509_certificate('/root/ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.crt') do
+    it { should be_certificate }
+    it { should be_valid }
+    it { should have_purpose 'server' }
+    include_examples 'certificate issuer', "C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}"
+    include_examples 'certificate subject', "C = US, ST = North Carolina, O = Katello, OU = SomeOrgUnit, CN = foreman-proxy.example.com"
+    its(:keylength) { should be >= 4096 }
+  end
+
+  describe x509_private_key('/root/ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.key') do
+    it { should_not be_encrypted }
+    it { should be_valid }
+    it { should have_matching_certificate('/root/ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.crt') }
+  end
+
   describe package("foreman-proxy.example.com-apache") do
     it { should be_installed }
+  end
+
+  describe file('/root/ssl-build/foreman-proxy.example.com') do
+    it { should be_directory }
+  end
+
+  describe file('/root/ssl-build/katello-default-ca.crt') do
+    it { should exist }
+  end
+
+  describe file('/root/ssl-build/katello-server-ca.crt') do
+    it { should exist }
   end
 end


### PR DESCRIPTION
Requires: https://github.com/theforeman/puppet-certs/pull/351

Adding a bit more than what is in the commit message. This is working towards an approach that we deploy certificates from the build directory to their managed locations and eventually drop the use of RPMs. This will cut down on the amount of locations certificates exist, the amount of processing by the puppet module and open this up for use on non-RPM systems.

In order to do this I am trying an approach of re-factoring underneath that does additive changes that allow the end state to remain unchanged while dismantling all of the RPM mechanisms. So in this case, include the certificates in the tarball, this will allow them to exist in `/root/ssl-build`. From there, we can begin to make changes such as in (https://github.com/theforeman/puppet-certs/pull/348) to deploy from the build directory. Once we are only deploying from the build directory across servers and content proxies the underlying RPM mechanisms can be disabled or removed entirely. Then we can begin to explore direct management of certificates in the puppet modules for the services (e.g. puppet-candlepin) by having split the generation of certificates from the deployment of certificates.