### PR TITLE
POC: show simple-deploy

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,55 +1,27 @@
 # Certs configurations for Apache
 class certs::apache (
-  $hostname             = $certs::node_fqdn,
-  $cname                = $certs::cname,
-  $generate             = $certs::generate,
-  $regenerate           = $certs::regenerate,
   Boolean $deploy = $certs::deploy,
   Stdlib::Absolutepath $pki_dir = $certs::pki_dir,
-  Optional[Stdlib::Absolutepath] $server_cert          = $certs::server_cert,
-  Optional[Stdlib::Absolutepath] $server_key           = $certs::server_key,
-  $country              = $certs::country,
-  $state                = $certs::state,
-  $city                 = $certs::city,
-  $org                  = $certs::org,
-  $org_unit             = $certs::org_unit,
-  $expiration           = $certs::expiration,
-  $default_ca           = $certs::default_ca,
-  $ca_key_password_file = $certs::ca_key_password_file,
-  $group                = 'root',
+  Optional[Stdlib::Absolutepath] $server_cert = $certs::server_cert,
+  Optional[Stdlib::Absolutepath] $server_key = $certs::server_key,
+  String[1] $group = 'root',
 ) inherits certs {
-
-  $apache_cert_name = "${hostname}-apache"
   $apache_cert = "${pki_dir}/certs/katello-apache.crt"
   $apache_key  = "${pki_dir}/private/katello-apache.key"
-  $apache_ca_cert = $certs::katello_server_ca_cert
 
   if $server_cert {
     $cert_source = $server_cert
     $key_source = $server_key
     $require = undef
-  } else {
-    cert { $apache_cert_name:
-      ensure        => present,
-      hostname      => $hostname,
-      cname         => $cname,
-      country       => $country,
-      state         => $state,
-      city          => $city,
-      org           => $org,
-      org_unit      => $org_unit,
-      expiration    => $expiration,
-      ca            => $default_ca,
-      generate      => $generate,
-      regenerate    => $regenerate,
-      deploy        => false,
-      password_file => $ca_key_password_file,
-      build_dir     => $certs::ssl_build_dir,
-    }
 
-    $cert_source = "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}.crt"
-    $key_source = "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}.key"
-    $require = Cert[$apache_cert_name]
+    $apache_ca_cert = $certs::katello_server_ca_cert
+  } else {
+    include certs::certificate
+    $cert_source = $certs::certificate::certificate_file
+    $key_source = $certs::certificate::private_key_file
+    $require = Class['certs::certificate']
+
+    $apache_ca_cert = $certs::certificate::ca_file
   }
 
   if $deploy {

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -1,0 +1,29 @@
+# @summary generate a certificate using the internal CA
+#
+# This ensures a certificate, key and CA exist.
+class certs::certificate {
+  include certs
+
+  cert { $title:
+    ensure        => present,
+    hostname      => $certs::node_fqdn,
+    cname         => $certs::cname,
+    country       => $certs::country,
+    state         => $certs::state,
+    city          => $certs::city,
+    org           => $certs::org,
+    org_unit      => $certs::org_unit,
+    expiration    => $certs::expiration,
+    ca            => $certs::default_ca,
+    generate      => $certs::generate,
+    regenerate    => $certs::regenerate,
+    deploy        => false,
+    password_file => $ca_key_password_file,
+    build_dir     => $certs::ssl_build_dir,
+    require       => Class['certs'],
+  }
+
+  $certificate_file = "${certs::ssl_build_dir}/${hostname}/${hostname}.crt"
+  $private_key_file = "${certs::ssl_build_dir}/${hostname}/${hostname}.key"
+  $ca_file = $certs::katello_default_ca_cert
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,7 +124,7 @@ class certs (
 
   Class['certs::install'] ->
   Class['certs::config'] ->
-  Class['certs::ca']
+  Class['certs::ca'] ->
 
   $default_ca = $certs::ca::default_ca
   $server_ca = $certs::ca::server_ca

--- a/manifests/key_pair.pp
+++ b/manifests/key_pair.pp
@@ -1,0 +1,34 @@
+define certs::key_pair (
+  Stdlib::Absolutepath $key_destination,
+  Stdlib::Absolutepath $cert_destination,
+  Enum['file', 'absent'] $ensure = 'file',
+  Optional[Stdlib::Absolutepath] $key_source = undef,
+  Optional[Stdlib::Absolutepath] $cert_source = undef,
+  Stdlib::Filemode $key_mode = '0640',
+  String[1] $key_owner = 'root',
+  String[1] $key_group = 'root',
+  Stdlib::Filemode $cert_mode = '0644',
+  String[1] $cert_owner = 'root',
+  String[1] $cert_group = 'root',
+) {
+  if $ensure == 'file' {
+    assert_type(NotUndef, $key_source)
+    assert_type(NotUndef, $cert_source)
+  }
+
+  file { $key_destination:
+    ensure => $ensure,
+    source => $key_source,
+    owner  => $key_owner,
+    group  => $key_group,
+    mode   => $key_mode,
+  }
+
+  file { $cert_destination:
+    ensure => $ensure,
+    source => $cert_source,
+    owner  => $cert_owner,
+    group  => $cert_group,
+    mode   => $cert_mode,
+  }
+}

--- a/spec/acceptance/apache_spec.rb
+++ b/spec/acceptance/apache_spec.rb
@@ -25,10 +25,6 @@ describe 'certs::apache' do
       it { should be_valid }
       it { should have_matching_certificate('/etc/pki/katello/certs/katello-apache.crt') }
     end
-
-    describe package("#{fact('fqdn')}-apache") do
-      it { should be_installed }
-    end
   end
 
   context 'with server cert' do
@@ -67,10 +63,6 @@ describe 'certs::apache' do
       it { should_not be_encrypted }
       it { should be_valid }
       it { should have_matching_certificate('/etc/pki/katello/certs/katello-apache.crt') }
-    end
-
-    describe package("#{fact('fqdn')}-apache") do
-      it { should be_installed }
     end
   end
 end


### PR DESCRIPTION
The goal of this to show how we can skip the intermediate RPM install phase and directly deploy.

It chooses to skip the cert resource if certificates are passed in.

This is an alternative to https://github.com/theforeman/puppet-certs/pull/348.