### PR TITLE
Test that foreman client_cert.pem has keylength >= 4096

### DIFF
--- a/spec/acceptance/foreman_spec.rb
+++ b/spec/acceptance/foreman_spec.rb
@@ -28,7 +28,7 @@ describe 'certs::foreman' do
       it { should have_purpose 'client' }
       include_examples 'certificate issuer', "C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{FQDN}"
       include_examples 'certificate subject', "C = US, ST = North Carolina, O = FOREMAN, OU = PUPPET, CN = #{FQDN}"
-      its(:keylength) { should be >= 2048 }
+      its(:keylength) { should be >= 4096 }
     end
 
     describe file('/etc/foreman/client_cert.pem') do


### PR DESCRIPTION
This was a minor oversight in 0a362f38a95b701e9dbd3b528a462c6212d5751a