### PR TITLE
Support ensuring certs::keypair cert and key can be absent

### DIFF
--- a/lib/puppet/provider/katello_ssl_tool.rb
+++ b/lib/puppet/provider/katello_ssl_tool.rb
@@ -18,6 +18,17 @@ module Puppet::Provider::KatelloSslTool
       deploy!   if deploy?
     end
 
+    def destroy
+      files_to_deploy.each do |file|
+        File.delete(file) if File.exist?(file)
+      end
+
+      output = execute([:rpm, '-q', rpmfile_base_name], failonfail: false)
+      if output.exitstatus == 0
+        rpm('-e', rpmfile_base_name)
+      end
+    end
+
     def self.details(cert_name)
       details = { :pubkey  => pubkey(cert_name),
                   :privkey   => privkey(cert_name) }
@@ -173,11 +184,16 @@ module Puppet::Provider::KatelloSslTool
 
     def exists?
       return false unless File.exists?(resource[:path])
+      return false unless File.exists?(source_path)
       expected_content_processed == current_content
     end
 
     def create
       File.open(resource[:path], "w", mode) { |f| f << expected_content_processed }
+    end
+
+    def destroy
+      File.delete(resource[:path]) if File.exist?(resource[:path])
     end
 
     protected

--- a/lib/puppet/provider/key_bundle/katello_ssl_tool.rb
+++ b/lib/puppet/provider/key_bundle/katello_ssl_tool.rb
@@ -2,6 +2,13 @@ require File.expand_path('../../katello_ssl_tool', __FILE__)
 
 Puppet::Type.type(:key_bundle).provide(:katello_ssl_tool, :parent => Puppet::Provider::KatelloSslTool::CertFile) do
 
+  def exists?
+    return false unless File.exists?(resource[:path])
+    return false unless File.exists?(privkey_source_path)
+    return false unless File.exists?(pubkey_source_path)
+    expected_content_processed == current_content
+  end
+
   protected
 
   def expected_content

--- a/lib/puppet_x/certs/common.rb
+++ b/lib/puppet_x/certs/common.rb
@@ -86,8 +86,15 @@ module PuppetX
         newparam(:key_pair) do
           validate do |value|
             param_resource = resource.catalog.resource(value.to_s)
-            if param_resource && !['Puppet::Type::Ca', 'Puppet::Type::Cert'].include?(param_resource.class.to_s)
-              raise ArgumentError, "Expected Ca or Cert resource, got #{param_resource.class} #{param_resource.inspect}"
+
+            if param_resource.is_a?(Puppet::Resource)
+              param_resource_type = param_resource.resource_type
+            else
+              param_resource_type = param_resource.to_resource.resource_type
+            end
+
+            if param_resource && !['Puppet::Type::Ca', 'Puppet::Type::Cert'].include?(param_resource_type.to_s)
+              raise ArgumentError, "Expected Ca or Cert resource, got #{param_resource} #{param_resource.inspect}"
             end
           end
         end

--- a/lib/puppet_x/certs/common.rb
+++ b/lib/puppet_x/certs/common.rb
@@ -87,14 +87,16 @@ module PuppetX
           validate do |value|
             param_resource = resource.catalog.resource(value.to_s)
 
-            if param_resource.is_a?(Puppet::Resource)
-              param_resource_type = param_resource.resource_type
-            else
-              param_resource_type = param_resource.to_resource.resource_type
-            end
+            if param_resource
+              param_resource_type = if param_resource.is_a?(Puppet::Resource)
+                                      param_resource.resource_type
+                                    else
+                                      param_resource.to_resource.resource_type
+                                    end
 
-            if param_resource && !['Puppet::Type::Ca', 'Puppet::Type::Cert'].include?(param_resource_type.to_s)
-              raise ArgumentError, "Expected Ca or Cert resource, got #{param_resource} #{param_resource.inspect}"
+              unless ['Puppet::Type::Ca', 'Puppet::Type::Cert'].include?(param_resource_type.to_s)
+                raise ArgumentError, "Expected Ca or Cert resource, got #{param_resource_type} #{param_resource.inspect}"
+              end
             end
           end
         end

--- a/manifests/keypair.pp
+++ b/manifests/keypair.pp
@@ -1,18 +1,19 @@
+# Deploy a key pair
 define certs::keypair (
   $key_pair,
-  $key_file,
-  $cert_file,
-  $manage_key  = false,
-  $key_owner   = undef,
-  $key_group   = undef,
-  $key_mode    = undef,
-  $manage_cert = false,
-  $cert_owner  = undef,
-  $cert_group  = undef,
-  $cert_mode   = undef,
-  $unprotect   = false,
-  $strip       = false,
-  $password_file = undef,
+  Stdlib::Absolutepath $key_file,
+  Stdlib::Absolutepath $cert_file,
+  Boolean $manage_key = false,
+  Optional[String[1]] $key_owner = undef,
+  Optional[String[1]] $key_group = undef,
+  Optional[Stdlib::Filemode] $key_mode = undef,
+  Boolean $manage_cert = false,
+  Optional[String[1]] $cert_owner = undef,
+  Optional[String[1]] $cert_group = undef,
+  Optional[Stdlib::Filemode] $cert_mode = undef,
+  Boolean $unprotect = false,
+  Boolean $strip = false,
+  Optional[Stdlib::Absolutepath] $password_file = undef,
 ) {
   $key_pair ~>
   privkey { $key_file:

--- a/manifests/keypair.pp
+++ b/manifests/keypair.pp
@@ -4,10 +4,12 @@ define certs::keypair (
   Stdlib::Absolutepath $key_file,
   Stdlib::Absolutepath $cert_file,
   Boolean $manage_key = false,
+  Enum['present', 'absent'] $ensure_key  = 'present',
   Optional[String[1]] $key_owner = undef,
   Optional[String[1]] $key_group = undef,
   Optional[Stdlib::Filemode] $key_mode = undef,
   Boolean $manage_cert = false,
+  Enum['present', 'absent'] $ensure_cert = 'present',
   Optional[String[1]] $cert_owner = undef,
   Optional[String[1]] $cert_group = undef,
   Optional[Stdlib::Filemode] $cert_mode = undef,
@@ -15,20 +17,24 @@ define certs::keypair (
   Boolean $strip = false,
   Optional[Stdlib::Absolutepath] $password_file = undef,
 ) {
-  $key_pair ~>
   privkey { $key_file:
+    ensure        => $ensure_key,
     key_pair      => $key_pair,
     unprotect     => $unprotect,
     password_file => $password_file,
-  } ~>
+    subscribe     => $key_pair,
+  }
+
   pubkey { $cert_file:
-    key_pair => $key_pair,
-    strip    => $strip,
+    ensure    => $ensure_cert,
+    key_pair  => $key_pair,
+    strip     => $strip,
+    subscribe => Privkey[$key_file],
   }
 
   if $manage_key {
     file { $key_file:
-      ensure  => file,
+      ensure  => $ensure_key,
       owner   => $key_owner,
       group   => $key_group,
       mode    => $key_mode,
@@ -38,7 +44,7 @@ define certs::keypair (
 
   if $manage_cert {
     file { $cert_file:
-      ensure  => file,
+      ensure  => $ensure_cert,
       owner   => $cert_owner,
       group   => $cert_group,
       mode    => $cert_mode,

--- a/spec/defines/keypair_spec.rb
+++ b/spec/defines/keypair_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'certs::keypair' do
+  let(:title) { 'mykeypair' }
+  let(:params) do
+    {
+      key_pair: 'Ca[default]',
+      key_file: '/path/to/key.pem',
+      cert_file: '/path/to/cert.pem',
+    }
+  end
+  let(:pre_condition) do
+    <<-PUPPET
+    ca { 'default':
+    }
+    PUPPET
+  end
+
+  context 'with minimal parameters' do
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_privkey('/path/to/key.pem')
+        .with_key_pair('Ca[default]')
+        .with_unprotect(false)
+        .with_password_file(nil)
+        .that_subscribes_to('Ca[default]')
+    end
+
+    it do
+      is_expected.to contain_pubkey('/path/to/cert.pem')
+        .with_key_pair('Ca[default]')
+        .with_strip(false)
+        .that_subscribes_to(['Ca[default]', 'Privkey[/path/to/key.pem]'])
+    end
+
+    it { is_expected.not_to contain_file('/path/to/key.pem') }
+    it { is_expected.not_to contain_file('/path/to/cert.pem') }
+  end
+
+  context 'with manage_key => true' do
+    let(:params) { super().merge(manage_key: true) }
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_file('/path/to/key.pem').that_requires('Privkey[/path/to/key.pem]') }
+    it { is_expected.not_to contain_file('/path/to/cert.pem') }
+  end
+
+  context 'with manage_cert => true' do
+    let(:params) { super().merge(manage_cert: true) }
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_file('/path/to/key.pem') }
+    it { is_expected.to contain_file('/path/to/cert.pem').that_requires('Pubkey[/path/to/cert.pem]') }
+  end
+end

--- a/spec/defines/keypair_spec.rb
+++ b/spec/defines/keypair_spec.rb
@@ -52,4 +52,33 @@ describe 'certs::keypair' do
     it { is_expected.not_to contain_file('/path/to/key.pem') }
     it { is_expected.to contain_file('/path/to/cert.pem').that_requires('Pubkey[/path/to/cert.pem]') }
   end
+
+  context 'with ensure_key => absent' do
+    let(:params) { super().merge(ensure_key: 'absent', manage_key: true) }
+
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_privkey('/path/to/key.pem')
+        .with_ensure('absent')
+        .with_key_pair('Ca[default]')
+        .with_unprotect(false)
+        .with_password_file(nil)
+        .that_subscribes_to('Ca[default]')
+    end
+    it { is_expected.to contain_file('/path/to/key.pem').with_ensure('absent').that_requires('Privkey[/path/to/key.pem]') }
+  end
+
+  context 'with ensure_cert => absent' do
+    let(:params) { super().merge(ensure_cert: 'absent', manage_cert: true) }
+
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_pubkey('/path/to/cert.pem')
+        .with_ensure('absent')
+        .with_key_pair('Ca[default]')
+        .with_strip(false)
+        .that_subscribes_to(['Ca[default]', 'Privkey[/path/to/key.pem]'])
+    end
+    it { is_expected.to contain_file('/path/to/cert.pem').with_ensure('absent').that_requires('Pubkey[/path/to/cert.pem]') }
+  end
 end


### PR DESCRIPTION
This includes https://github.com/theforeman/puppet-certs/pull/313/commits/862fc57d27aece10ab182236f5bd2fbb91390217 with a small fix to allow tests to pass (thanks @ekohl !).