### PR TITLE
Refs #32585 - Return OpenSSL compat in cert subject

### DIFF
--- a/lib/puppet/functions/certs/certificate_subject.rb
+++ b/lib/puppet/functions/certs/certificate_subject.rb
@@ -14,7 +14,7 @@ Puppet::Functions.create_function(:'certs::certificate_subject') do
   def certificate_subject(certificate_path)
     begin
       cert = OpenSSL::X509::Certificate.new(File.read(certificate_path))
-      cert.subject.to_s(OpenSSL::X509::Name::RFC2253)
+      cert.subject.to_s(OpenSSL::X509::Name::COMPAT)
     rescue OpenSSL::X509::CertificateError, Errno::ENOENT => e
       Puppet.debug("The file at #{certificate_path} could not be read or is not a valid x509 certificate: #{e}")
       nil

--- a/spec/functions/certs_certificate_subject_spec.rb
+++ b/spec/functions/certs_certificate_subject_spec.rb
@@ -85,7 +85,7 @@ describe 'certs::certificate_subject' do
       end
 
       it 'should return a certificate subject in OpenSSL compat format' do
-        is_expected.to run.with_params('/tmp/client_cert.crt').and_return("C=US,O=Internet Security Research Group,CN=ISRG Root X1")
+        is_expected.to run.with_params('/tmp/client_cert.crt').and_return("C=US, O=Internet Security Research Group, CN=ISRG Root X1")
       end
     end
 

--- a/spec/functions/certs_certificate_subject_spec.rb
+++ b/spec/functions/certs_certificate_subject_spec.rb
@@ -1,50 +1,98 @@
 require 'spec_helper'
 
 describe 'certs::certificate_subject' do
-  let(:test_cert) do
-    <<~CERT
-      -----BEGIN CERTIFICATE-----
-      MIIC+TCCAeGgAwIBAgIUetO+zvwJ4nLNrxe9lcrT4h0noCMwDQYJKoZIhvcNAQEL
-      BQAwHjEcMBoGA1UEAwwTVGVzdCBTZWxmLVNpZ25lZCBDQTAeFw0yMDExMTgwMjMw
-      NDNaFw0zMDExMTYwMjMwNDNaMB4xHDAaBgNVBAMME2ZvcmVtYW4uZXhhbXBsZS5j
-      b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDcEtPd1uKX0hct7+qe
-      gOEy72VB93cBGuEJis6yD7uJfdjnbBtiFwkxUqmQlsDmUsqcuh6106yDkaW6tyzT
-      I6R0Xx8OJkT4bxOsgkr3xqZSrAQJvn/NmV4j6egckJlgYnSbkrOFvy5iO1A/Dc/m
-      OrC6TJVGe/YvMCU6IYPU1f/acNucRZGopa7yfhyTd8nzArq1BCSrjqtCl8m9NPJZ
-      IP8+06wQ6MCjyd+kjnm+Tq/P+mKEsXVDBQCQAyWFpZdUcu4zbL+UV2+O7QUtndEh
-      k2nf4w3Rx70XvMwagfo3hE5cJ8rNXEynphhDzdJqzRDpPYItZauMDxmK+4oHOn0g
-      90t5AgMBAAGjLzAtMAsGA1UdDwQEAwIFIDAeBgNVHREEFzAVghNmb3JlbWFuLmV4
-      YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBlIEA2CfZIa8LtUYlDwa5v+5Wf
-      1ktmYTRtgEI+922T/eTB8uH1//VxpfK5ynljao7SNVcX+74Q+YH/4Ci4OfZvE5vA
-      1IJXog5bfE4mVc1qXhH7TokBQx1L6vtUh9OaTGpBAVnS3J5jLw6+Tdi9FOeZdKHZ
-      FvMnyZ7MQ6VjbLZsTy49o87Nstqkle48ivwSFrDU1cDN+6S/DUdHQnh8XtPB1PMh
-      7WCxGGtzmw5s5SxBkyY/buGDr+kx52yULl6ZrnJD6PfR30X+8G3ltvmaCQllYadX
-      eprUs5H2WDnTUUE78+cf1JK29Zs9it/l4t2uLc5Z94oXosFLkTKw6ZSB3X9J
-      -----END CERTIFICATE-----
-    CERT
-  end
 
   it 'should exist' do
     is_expected.not_to eq(nil)
   end
 
-  it 'should return a certificate subject in RFC2253 format' do
-    file = class_double("File")
-    allow(File).to receive(:read).and_call_original
-    allow(File).to receive(:read).with("/tmp/client_cert.crt").and_return(test_cert)
-
-    is_expected.to run.with_params('/tmp/client_cert.crt').and_return("CN=foreman.example.com")
-  end
-
-  it 'should handle a bad certificate' do
-    file = class_double("File")
-    allow(File).to receive(:read).and_call_original
-    allow(File).to receive(:read).with("/tmp/client_cert.crt").and_return('aab32433adfad')
-
-    is_expected.to run.with_params('/tmp/client_cert.crt').and_return(nil)
-  end
-
   it 'should handle a non-existent file' do
     is_expected.to run.with_params('/tmp/client_cert.crt').and_return(nil)
+  end
+
+  context 'with certificate' do
+    before do
+      file = class_double("File")
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with("/tmp/client_cert.crt").and_return(certificate)
+    end
+
+    context 'containing only a CN' do
+      let(:certificate) do
+        <<~CERT
+          -----BEGIN CERTIFICATE-----
+          MIIC+TCCAeGgAwIBAgIUetO+zvwJ4nLNrxe9lcrT4h0noCMwDQYJKoZIhvcNAQEL
+          BQAwHjEcMBoGA1UEAwwTVGVzdCBTZWxmLVNpZ25lZCBDQTAeFw0yMDExMTgwMjMw
+          NDNaFw0zMDExMTYwMjMwNDNaMB4xHDAaBgNVBAMME2ZvcmVtYW4uZXhhbXBsZS5j
+          b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDcEtPd1uKX0hct7+qe
+          gOEy72VB93cBGuEJis6yD7uJfdjnbBtiFwkxUqmQlsDmUsqcuh6106yDkaW6tyzT
+          I6R0Xx8OJkT4bxOsgkr3xqZSrAQJvn/NmV4j6egckJlgYnSbkrOFvy5iO1A/Dc/m
+          OrC6TJVGe/YvMCU6IYPU1f/acNucRZGopa7yfhyTd8nzArq1BCSrjqtCl8m9NPJZ
+          IP8+06wQ6MCjyd+kjnm+Tq/P+mKEsXVDBQCQAyWFpZdUcu4zbL+UV2+O7QUtndEh
+          k2nf4w3Rx70XvMwagfo3hE5cJ8rNXEynphhDzdJqzRDpPYItZauMDxmK+4oHOn0g
+          90t5AgMBAAGjLzAtMAsGA1UdDwQEAwIFIDAeBgNVHREEFzAVghNmb3JlbWFuLmV4
+          YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBlIEA2CfZIa8LtUYlDwa5v+5Wf
+          1ktmYTRtgEI+922T/eTB8uH1//VxpfK5ynljao7SNVcX+74Q+YH/4Ci4OfZvE5vA
+          1IJXog5bfE4mVc1qXhH7TokBQx1L6vtUh9OaTGpBAVnS3J5jLw6+Tdi9FOeZdKHZ
+          FvMnyZ7MQ6VjbLZsTy49o87Nstqkle48ivwSFrDU1cDN+6S/DUdHQnh8XtPB1PMh
+          7WCxGGtzmw5s5SxBkyY/buGDr+kx52yULl6ZrnJD6PfR30X+8G3ltvmaCQllYadX
+          eprUs5H2WDnTUUE78+cf1JK29Zs9it/l4t2uLc5Z94oXosFLkTKw6ZSB3X9J
+          -----END CERTIFICATE-----
+        CERT
+      end
+
+      it 'should return a certificate subject in OpenSSL compat format' do
+        is_expected.to run.with_params('/tmp/client_cert.crt').and_return("CN=foreman.example.com")
+      end
+    end
+
+    context 'containing multiple components' do
+      let(:certificate) do
+        # ISRG Root X1
+        <<~CERT
+          -----BEGIN CERTIFICATE-----
+          MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+          TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+          cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+          WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+          ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+          MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+          h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+          0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+          A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+          T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+          B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+          B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+          KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+          OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+          jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+          qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+          rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+          HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+          hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+          ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+          3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+          NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+          ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+          TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+          jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+          oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+          4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+          mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+          emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+          -----END CERTIFICATE-----
+        CERT
+      end
+
+      it 'should return a certificate subject in OpenSSL compat format' do
+        is_expected.to run.with_params('/tmp/client_cert.crt').and_return("C=US,O=Internet Security Research Group,CN=ISRG Root X1")
+      end
+    end
+
+    context 'that is invalid' do
+      let(:certificate) { 'aab32433adfad' }
+
+      it { is_expected.to run.with_params('/tmp/client_cert.crt').and_return(nil) }
+    end
   end
 end


### PR DESCRIPTION
Artemis requires the compat format to match a certificate and doesn't accept the RFC2253 format.

It first includes a commit to arrange the tests in a way that makes it very clear what the actual change is.

The whole issue wasn't caught because our example certificate only contained a single component (CN) so the spacing wasn't relevant.