### PR TITLE
Manage the certs::foreman ssl_ca_file

### DIFF
--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -60,5 +60,13 @@ class certs::foreman (
     pubkey { $ssl_ca_cert:
       key_pair => $server_ca,
     }
+
+    file { $ssl_ca_cert:
+      ensure  => file,
+      owner   => $owner,
+      group   => $group,
+      mode    => '0440',
+      require => Pubkey[$ssl_ca_cert],
+    }
   }
 }

--- a/spec/acceptance/foreman_spec.rb
+++ b/spec/acceptance/foreman_spec.rb
@@ -59,6 +59,13 @@ describe 'certs::foreman' do
       its(:keylength) { should be >= 4096 }
     end
 
+    describe file('/etc/foreman/proxy_ca.pem') do
+      it { should be_file }
+      it { should be_mode 440 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'foreman' }
+    end
+
     describe x509_certificate("/root/ssl-build/#{fqdn}/#{fqdn}-foreman-client.crt") do
       it { should be_certificate }
       it { should be_valid }


### PR DESCRIPTION
This manages the ssl_ca_file in certs::foreman ensuring the right
owner and group are set and allowing users of this class to customize
it if needed.

@ekohl Needed to implement https://github.com/ekohl/puppet-katello_devel/commit/8e2f945cd4e70d8e39737ad5a90c3e431442f22b otherwise the `proxy_ca.pem` file would end up owned by root:root.