### PR TITLE
Keep Candlepin CA key password protected

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -91,7 +91,6 @@ class certs::candlepin (
       key_group     => 'tomcat',
       key_mode      => '0440',
       cert_mode     => '0640',
-      unprotect     => true,
       strip         => true,
       password_file => $ca_key_password_file,
     }


### PR DESCRIPTION
Candlepin supports configuring a CA key password, so deploying the
CA key to Candlepin unprotected only complicates deployment by having
to run an intermediary step to unprotect it. Let the key be deployed
as is and configure Candlepin appropriately.