### PR TITLE
Allow passing string for hostname to certs::qpid_router::client

### DIFF
--- a/manifests/qpid_router/client.pp
+++ b/manifests/qpid_router/client.pp
@@ -1,6 +1,6 @@
 # Constains certs specific configurations for qpid dispatch router
 class certs::qpid_router::client (
-  Stdlib::Fqdn $hostname = $certs::node_fqdn,
+  String $hostname = $certs::node_fqdn,
   Array[Stdlib::Fqdn] $cname = $certs::cname,
   Boolean $generate = $certs::generate,
   Boolean $regenerate = $certs::regenerate,


### PR DESCRIPTION
Fixes:

```
    # 2021-08-03 15:20:10 [ERROR ] [configure] Evaluation Error: Error while evaluating a Resource Statement, Class[Certs::Qpid_router::Client]: parameter 'hostname' expects a match for Stdlib::Fqdn = Pattern[/\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z/], got 'qpid_router_katello_agent' (file: /usr/share/foreman-installer/modules/foreman_proxy_content/manifests/dispatch_router/hub.pp, line: 22, column: 3) on node pipe-katello-server-nightly-centos8.wareagle.example.com
```

When configuring the client certificates, we configure a string for the "hostname" (CN) as part of the SASL configuration to identify the user.