### PR TITLE
New cert key bundle type

### DIFF
--- a/lib/puppet/type/cert_key_bundle.rb
+++ b/lib/puppet/type/cert_key_bundle.rb
@@ -1,0 +1,96 @@
+Puppet::Type.newtype(:cert_key_bundle) do
+  desc 'combines a certificate and private key into a single file'
+
+  ensurable
+
+  newparam(:path, :namevar => true) do
+    desc "Path to the file that will contain the certificate and private key bundle"
+    isrequired
+  end
+
+  newparam(:certificate) do
+    desc "Path to certificate file to include in bundle"
+    isrequired
+
+    def insync?(is)
+      File.read(self[:path]).include?(File.read(should))
+    end
+  end
+
+  newparam(:private_key) do
+    desc "Path to private key file to include in bundle"
+    isrequired
+
+    def insync?(is)
+      should = format_as_pkcs_1(should) if self[:force_pkcs_1]
+      File.read(self[:path]).include?(File.read(should))
+    end
+  end
+
+  newparam(:owner, parent: Puppet::Type::File::Owner) do
+    desc "Specifies the owner of the file. Valid options: a string containing a username or integer containing a uid."
+  end
+
+  newparam(:group, parent: Puppet::Type::File::Group) do
+    desc "Specifies a permissions group for the file. Valid options: a string containing a group name or integer containing a gid."
+  end
+
+  newparam(:mode, parent: Puppet::Type::File::Mode) do
+    desc "Specifies the permissions mode of the file. Valid options: a string containing a permission mode value in octal notation."
+  end
+
+  newparam(:force_pkcs_1, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Ensures the private key is in PKCS#1 format. This is required for services like Apache reverse proxy"
+  end
+
+  def create
+    File.write(self[:path], bundle)
+  end
+
+  def exists?
+    return false unless File.exist?(self[:path])
+    bundle == File.read(self[:path])
+  end
+
+  def destroy
+    File.rm(self[:path])
+  end
+
+  def bundle
+    cert = File.read(self[:certificate])
+    key = File.read(self[:private_key])
+
+    key = format_as_pkcs_1(key) if self[:force_pkcs_1]
+
+    [key, cert].join("\n")
+  end
+
+  def format_as_pkcs_1(content)
+    content.gsub(/(BEGIN|END) (PRIVATE KEY)/, '\1 RSA \2')
+  end
+
+  def generate
+    file_opts = {
+      ensure: (self[:ensure] == :absent) ? :absent : :file,
+      show_diff: false,
+    }
+
+    [:owner,
+     :path,
+     :group,
+     :mode].each do |param|
+      file_opts[param] = self[param] unless self[param].nil?
+    end
+
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
+    end
+
+    [Puppet::Type.type(:file).new(file_opts)]
+  end
+
+end

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -124,16 +124,17 @@ class certs::foreman_proxy (
     } ->
     pubkey { $foreman_ssl_ca_cert:
       key_pair => $server_ca,
-    } ~>
-    key_bundle { $foreman_proxy_ssl_client_bundle:
-      key_pair  => Cert[$foreman_proxy_client_cert_name],
-      force_rsa => true,
-    } ~>
-    file { $foreman_proxy_ssl_client_bundle:
-      ensure => file,
-      owner  => 'root',
-      group  => $group,
-      mode   => $public_key_mode,
+    }
+
+    cert_key_bundle { $foreman_proxy_ssl_client_bundle:
+      ensure       => present,
+      certificate  => $foreman_ssl_cert,
+      private_key  => $foreman_ssl_key,
+      force_pkcs_1 => true,
+      owner        => 'root',
+      group        => $group,
+      mode         => $public_key_mode,
+      require      => Certs::Keypair['foreman_proxy_client'],
     }
 
   }

--- a/spec/acceptance/foreman_proxy_spec.rb
+++ b/spec/acceptance/foreman_proxy_spec.rb
@@ -99,5 +99,28 @@ describe 'certs::foreman_proxy' do
       its(:subject) { should eq("C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fqdn}") }
       its(:keylength) { should be >= 4096 }
     end
+
+    describe file("/etc/pki/katello/private/#{fqdn}-foreman-proxy-client-bundle.pem") do
+      it { should be_file }
+      it { should be_mode 444 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'foreman-proxy' }
+    end
+
+    describe x509_certificate("/etc/pki/katello/private/#{fqdn}-foreman-proxy-client-bundle.pem") do
+      it { should be_certificate }
+      it { should be_valid }
+      it { should have_purpose 'client' }
+      its(:issuer) { should eq("C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fqdn}") }
+      its(:subject) { should eq("C = US, ST = North Carolina, O = FOREMAN, OU = FOREMAN_PROXY, CN = #{fqdn}") }
+      its(:keylength) { should be >= 4096 }
+    end
+
+    describe x509_private_key("/etc/pki/katello/private/#{fqdn}-foreman-proxy-client-bundle.pem") do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate("/etc/pki/katello/private/#{fqdn}-foreman-proxy-client-bundle.pem") }
+    end
+
   end
 end

--- a/spec/acceptance/foreman_proxy_spec.rb
+++ b/spec/acceptance/foreman_proxy_spec.rb
@@ -105,6 +105,7 @@ describe 'certs::foreman_proxy' do
       it { should be_mode 444 }
       it { should be_owned_by 'root' }
       it { should be_grouped_into 'foreman-proxy' }
+      its(:content) { should include('BEGIN RSA PRIVATE KEY') }
     end
 
     describe x509_certificate("/etc/pki/katello/private/#{fqdn}-foreman-proxy-client-bundle.pem") do


### PR DESCRIPTION
Adds a new type to create a bundle of a certificate and private key
that relies on certificate and private key paths being supplied. The
current key_bundle type is tied closely to the underlying katello-certs-tools
based types. This new type is more widely usable across use cases and
combines the ability to manage file properties.