### PR TITLE
Add test to check tar archive contents

### DIFF
--- a/spec/acceptance/certs_tar_extract_spec.rb
+++ b/spec/acceptance/certs_tar_extract_spec.rb
@@ -37,6 +37,10 @@ describe 'certs with tar archive' do
     apply_manifest(install_certs, catch_failures: true)
   end
 
+  after(:context) do
+    on default, 'yum -y remove foreman-proxy.example.com*noarch*'
+  end
+
   describe x509_certificate('/etc/pki/katello/certs/katello-apache.crt') do
     it { should be_certificate }
     it { should be_valid }

--- a/spec/acceptance/foreman_proxy_content_spec.rb
+++ b/spec/acceptance/foreman_proxy_content_spec.rb
@@ -24,8 +24,42 @@ describe 'certs::foreman_proxy_content' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe file('/root/foreman-proxy.example.com.tar.gz') do
+    let(:expected_files_in_tar) do
+      [
+        'ssl-build/katello-default-ca-1.0-1.noarch.rpm',
+        'ssl-build/katello-server-ca-1.0-1.noarch.rpm',
+        'ssl-build/katello-default-ca.crt',
+        'ssl-build/katello-server-ca.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-broker-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-router-client-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-router-server-1.0-1.noarch.rpm',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-broker.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-router-client.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-router-server.crt',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-broker.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-router-client.key',
+        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-qpid-router-server.key',
+      ]
+    end
+
+    describe tar('/root/foreman-proxy.example.com.tar.gz') do
       it { should exist }
+      its(:contents) { should match_array(expected_files_in_tar) }
     end
   end
 end

--- a/spec/support/acceptance/tar.rb
+++ b/spec/support/acceptance/tar.rb
@@ -1,0 +1,37 @@
+begin
+  require 'serverspec'
+rescue LoadError
+  # Not using acceptance tests
+else
+  module Serverspec
+    module Type
+      class Tar < Command
+        def contents
+          command_result.stdout.split("\n")
+        end
+
+        def exist?
+          @runner.check_file_exists(@name)
+        end
+
+        private
+
+        def command
+          "tar -tf #{@name}"
+        end
+
+        def command_result
+          @command_result ||= @runner.run_command(command)
+        end
+      end
+    end
+
+    module Helper
+      module Type
+        def tar(*args)
+          Serverspec::Type::Tar.new(*args)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Aims to allow testing for regressions when certificates are added
or removed when aiming to support Katello N-1 support. Additionally
aims to detect if new items are added that should be checked for.