### PR TITLE
Reintroduce $apache_ca_cert

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -23,6 +23,8 @@ class certs::apache (
   $apache_cert_name = "${hostname}-apache"
   $apache_cert = "${pki_dir}/certs/katello-apache.crt"
   $apache_key  = "${pki_dir}/private/katello-apache.key"
+  # This variable is unused but considered public API
+  $apache_ca_cert = $certs::katello_server_ca_cert
 
   if $server_cert {
     cert { $apache_cert_name:


### PR DESCRIPTION
In 8c5404ff76aca156be16f81b1f21b630a067b2c2 this was removed, but it was considered a public API. It makes it easy for consumers to know what the actual CA is.

Fixes: 8c5404ff76aca156be16f81b1f21b630a067b2c2