### PR TITLE
Correctly pass the path to the tempfile when adding keystore certific…

### DIFF
--- a/lib/puppet/provider/keystore_certificate/openssl.rb
+++ b/lib/puppet/provider/keystore_certificate/openssl.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:keystore_certificate).provide(:openssl) do
         '-export',
         '-in', resource[:certificate],
         '-inkey', resource[:private_key],
-        '-out', temp_store,
+        '-out', temp_store.path,
         '-name', resource[:alias],
         '-CAfile', resource[:ca],
         '-password', "file:#{resource[:password_file]}"
@@ -47,7 +47,7 @@ Puppet::Type.type(:keystore_certificate).provide(:openssl) do
       keytool(
         '-importkeystore',
         '-noprompt',
-        '-srckeystore', temp_store,
+        '-srckeystore', temp_store.path,
         '-srcstorepass:file', resource[:password_file],
         '-destkeystore', resource[:keystore],
         '-deststorepass:file', resource[:password_file],


### PR DESCRIPTION
…ates

This was previously pass the name of the File object in Ruby to
keytool creating a temporary file at the location that the module
is executed at to serve as the temporary file. This means that
the result continues to work -- a keystore certificates is imported
into the final destination but it was leaving behind residual files.

If you spin up a Forklift based installation of Katello, you will for example see `'#<File:0x0000000007df8a20>'` in the vagrant home directory.