### PR TITLE
Fixes #34189: Unencrypt CA key when deploying for Candlepin

### DIFF
--- a/lib/puppet/provider/private_key/openssl.rb
+++ b/lib/puppet/provider/private_key/openssl.rb
@@ -1,0 +1,45 @@
+Puppet::Type.type(:private_key).provide(:openssl) do
+  commands :openssl => 'openssl'
+
+  def create
+    File.write(resource[:path], private_key_content)
+  end
+
+  def destroy
+    delete_private_key
+  end
+
+  def exists?
+    File.exist?(resource[:path]) && File.read(resource[:path]) == private_key_content
+  end
+
+  private
+
+  def private_key_content
+    key_path = full_path(resource[:source][0])
+
+    if resource[:decrypt]
+      decrypt(key_path, resource[:password_file])
+    else
+      File.read(key_path)
+    end
+  end
+
+  def delete_private_key
+    File.unlink(resource[:path])
+  end
+
+  def full_path(source)
+    Puppet::Util.uri_to_path(URI.parse(Puppet::Util.uri_encode(source)))
+  end
+
+  def decrypt(path, password_file)
+    openssl(
+      'rsa',
+      '-in', path,
+      '-passin', "file:#{password_file}",
+      '-text'
+    )
+  end
+
+end

--- a/lib/puppet/type/private_key.rb
+++ b/lib/puppet/type/private_key.rb
@@ -1,0 +1,66 @@
+Puppet::Type.newtype(:private_key) do
+  desc 'manage a private key'
+
+  ensurable
+
+  newparam(:path, :namevar => true) do
+    desc "Path to the private key file"
+    isrequired
+  end
+
+  newparam(:password_file) do
+    desc "Path to file containing the private key file password"
+  end
+
+  newparam(:decrypt, parent: Puppet::Parameter::Boolean) do
+    desc "If true, decrypts the private key before writing to disk. Requires password_file parameter to be set"
+  end
+
+  newparam(:owner, parent: Puppet::Type::File::Owner) do
+    desc "Specifies the owner of the private key. Valid options: a string containing a username or integer containing a uid."
+  end
+
+  newparam(:group, parent: Puppet::Type::File::Group) do
+    desc "Specifies a permissions group for the private key. Valid options: a string containing a group name or integer containing a gid."
+  end
+
+  newparam(:mode, parent: Puppet::Type::File::Mode) do
+    desc "Specifies the permissions mode of the private key. Valid options: a string containing a permission mode value in octal notation."
+  end
+
+  newparam(:source, parent: Puppet::Type::File::ParameterSource) do
+    desc "Specifies the source of the private key."
+    isrequired
+  end
+
+  validate do
+    self.fail _("You cannot specify to decrypt without including a password file") if self[:decrypt] && !self[:password_file]
+  end
+
+  autorequire(:file) do
+    [self[:password_file], self[:path], self[:source]]
+  end
+
+  def generate
+    file_opts = {
+      ensure: (self[:ensure] == :absent) ? :absent : :file,
+    }
+
+    [:path,
+     :owner,
+     :group,
+     :mode].each do |param|
+      file_opts[param] = self[param] unless self[param].nil?
+    end
+
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
+    end
+
+    [Puppet::Type.type(:file).new(file_opts)]
+  end
+end

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -78,16 +78,18 @@ class certs::candlepin (
 
   if $deploy {
     certs::keypair { $certs::default_ca_name:
-      source_dir => $certs::ssl_build_dir,
-      key_file   => $ca_key,
-      key_owner  => $user,
-      key_group  => $group,
-      key_mode   => '0440',
-      cert_file  => $ca_cert,
-      cert_owner => $user,
-      cert_group => $group,
-      cert_mode  => '0440',
-      require    => $default_ca,
+      source_dir        => $certs::ssl_build_dir,
+      key_file          => $ca_key,
+      key_owner         => $user,
+      key_group         => $group,
+      key_mode          => '0440',
+      cert_file         => $ca_cert,
+      cert_owner        => $user,
+      cert_group        => $group,
+      cert_mode         => '0440',
+      require           => $default_ca,
+      key_password_file => $ca_key_password_file,
+      key_decrypt       => true,
     }
 
     file { "${pki_dir}/private/katello-tomcat.key":

--- a/manifests/keypair.pp
+++ b/manifests/keypair.pp
@@ -12,15 +12,18 @@ define certs::keypair (
   String $cert_owner = 'root',
   String $cert_group = undef,
   Stdlib::Filemode $cert_mode = '440',
+  Boolean $key_decrypt = false,
+  Optional[Stdlib::Absolutepath] $key_password_file = undef,
 ) {
 
-  file { $key_file:
-    ensure    => $key_ensure,
-    source    => "${source_dir}/${title}.key",
-    owner     => $key_owner,
-    group     => $key_group,
-    mode      => $key_mode,
-    show_diff => false,
+  private_key { $key_file:
+    ensure        => $key_ensure,
+    source        => "${source_dir}/${title}.key",
+    decrypt       => $key_decrypt,
+    password_file => $key_password_file,
+    owner         => $key_owner,
+    group         => $key_group,
+    mode          => $key_mode,
   }
 
   file { $cert_file:

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -153,6 +153,11 @@ describe 'certs' do
       it { should be_grouped_into 'tomcat' }
     end
 
+    describe x509_private_key('/etc/candlepin/certs/candlepin-ca.key') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+    end
+
     describe file('/etc/candlepin/certs/candlepin-ca.key') do
       it { should be_file }
       it { should be_mode 440 }

--- a/spec/defines/keypair_spec.rb
+++ b/spec/defines/keypair_spec.rb
@@ -21,13 +21,12 @@ describe 'certs::keypair' do
   context 'with minimal parameters' do
     it { is_expected.to compile.with_all_deps }
     it do
-      is_expected.to contain_file('/path/to/key.pem')
+      is_expected.to contain_private_key('/path/to/key.pem')
         .with_ensure('present')
         .with_source('/root/ssl-build/example.com/mykeypair.key')
         .with_owner('root')
         .with_group('root')
         .with_mode('440')
-        .with_show_diff(false)
     end
 
     it do
@@ -45,13 +44,12 @@ describe 'certs::keypair' do
 
     it { is_expected.to compile.with_all_deps }
     it do
-      is_expected.to contain_file('/path/to/key.pem')
+      is_expected.to contain_private_key('/path/to/key.pem')
         .with_ensure('absent')
         .with_source('/root/ssl-build/example.com/mykeypair.key')
         .with_owner('root')
         .with_group('root')
         .with_mode('440')
-        .with_show_diff(false)
     end
 
     it do


### PR DESCRIPTION
Introduces a new type and provider for managing a private key file.
Has the ability to decrypt the private key file when deploying
which is needed for Candlepin deployments.