### PR TITLE
Fixes #34598: Disable fips for keytool 

### DIFF
--- a/lib/puppet/provider/keystore_certificate/openssl.rb
+++ b/lib/puppet/provider/keystore_certificate/openssl.rb
@@ -52,7 +52,8 @@ Puppet::Type.type(:keystore_certificate).provide(:openssl) do
         '-destkeystore', resource[:keystore],
         '-deststorepass:file', resource[:password_file],
         '-srcalias', resource[:alias],
-        '-destalias', resource[:alias]
+        '-destalias', resource[:alias],
+        '-J-Dcom.redhat.fips=false'
       )
     end
   rescue Puppet::ExecutionFailure => e
@@ -66,7 +67,8 @@ Puppet::Type.type(:keystore_certificate).provide(:openssl) do
       '-noprompt',
       '-keystore', resource[:keystore],
       '-alias', resource[:alias],
-      '-storepass:file', resource[:password_file]
+      '-storepass:file', resource[:password_file],
+      '-J-Dcom.redhat.fips=false'
     )
   end
 
@@ -78,7 +80,8 @@ Puppet::Type.type(:keystore_certificate).provide(:openssl) do
       '-list',
       '-keystore', resource[:keystore],
       '-storepass:file', resource[:password_file],
-      '-alias', resource[:alias]
+      '-alias', resource[:alias],
+      '-J-Dcom.redhat.fips=false'
     )
   rescue Puppet::ExecutionFailure => e
     Puppet.debug("Failed to read keystore contents: #{e}")

--- a/lib/puppet/provider/truststore_certificate/keytool.rb
+++ b/lib/puppet/provider/truststore_certificate/keytool.rb
@@ -49,7 +49,8 @@ Puppet::Type.type(:truststore_certificate).provide(:keytool) do
       '-file',
       resource[:certificate],
       '-storepass:file',
-      resource[:password_file]
+      resource[:password_file],
+      '-J-Dcom.redhat.fips=false'
     )
   end
 
@@ -63,7 +64,8 @@ Puppet::Type.type(:truststore_certificate).provide(:keytool) do
       '-alias',
       resource[:alias],
       '-storepass:file',
-      resource[:password_file]
+      resource[:password_file],
+      '-J-Dcom.redhat.fips=false'
     )
   end
 
@@ -76,6 +78,7 @@ Puppet::Type.type(:truststore_certificate).provide(:keytool) do
       '-keystore', resource[:truststore],
       '-storepass:file', resource[:password_file],
       '-alias', resource[:alias],
+      '-J-Dcom.redhat.fips=false'
     )
   rescue Puppet::ExecutionFailure => e
     Puppet.debug("Failed to read truststore contents: #{e}")

--- a/lib/puppet_x/certs/provider/keystore.rb
+++ b/lib/puppet_x/certs/provider/keystore.rb
@@ -32,7 +32,8 @@ module Puppet_X
               '-keystore', store,
               '-storepass:file', resource[:password_file],
               '-alias', temp_alias,
-              '-dname', "CN=#{temp_alias}"
+              '-dname', "CN=#{temp_alias}",
+              '-J-Dcom.redhat.fips=false'
             )
           rescue Puppet::ExecutionFailure => e
             Puppet.err("Failed to generate new #{type} with temporary entry: #{e}")
@@ -44,7 +45,8 @@ module Puppet_X
               '-delete',
               '-keystore', store,
               '-storepass:file', resource[:password_file],
-              '-alias', temp_alias
+              '-alias', temp_alias,
+              '-J-Dcom.redhat.fips=false'
             )
           rescue Puppet::ExecutionFailure => e
             Puppet.err("Failed to delete temporary entry when generating empty #{type}: #{e}")


### PR DESCRIPTION
Starting with EL 8, the Java stack has FIPS support built in. This
causes the keytool utility to break on FIPS enabled machines. To solve this,
and achieve EL7-like comptability for FIPS, FIPS is disabled during the keytool
runtime via -Dcom.redhat.fips=false for each invoke of keytool.