### PR TITLE
Deploy server CA certificate for smart-proxy rather than default

### DIFF
--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -107,13 +107,26 @@ class certs::foreman_proxy (
       require    => Cert[$proxy_cert_name],
     }
 
-    file { $proxy_ca_cert:
-      ensure  => file,
-      source  => $default_ca_cert,
+    concat { $proxy_ca_cert:
+      ensure  => present,
       owner   => $owner,
       group   => $group,
       mode    => '0440',
-      require => File[$default_ca_cert],
+      require => File[$server_ca_cert],
+    }
+
+    concat::fragment { 'default_ca_cert':
+      target => $proxy_ca_cert,
+      source => $default_ca_cert,
+      order  => '01',
+    }
+
+    if $server_cert {
+      concat::fragment { 'server_ca_cert':
+        target => $proxy_ca_cert,
+        source => $server_ca_cert,
+        order  => '02',
+      }
     }
 
     certs::keypair { $foreman_proxy_client_cert_name:

--- a/spec/acceptance/foreman_proxy_spec.rb
+++ b/spec/acceptance/foreman_proxy_spec.rb
@@ -162,6 +162,59 @@ describe 'certs::foreman_proxy' do
     end
   end
 
+  context 'with server cert' do
+    before(:context) do
+      ['.crt', '.key', '-chain.pem'].each do |ext|
+        source_path = "fixtures/example.partial.solutions#{ext}"
+        dest_path = "/server#{ext}"
+        scp_to(hosts, source_path, dest_path)
+      end
+
+      # Force regen
+      on hosts, "if [ -e /root/ssl-build/#{fact('fqdn')} ] ; then touch /root/ssl-build/#{fact('fqdn')}/#{fact('fqdn')}-foreman-proxy.update ; fi"
+    end
+
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        file { '/server-chain.pem':
+          ensure => present,
+        }
+
+        class { '::certs::foreman_proxy':
+          server_ca_cert => '/server-chain.pem',
+          server_cert    => '/server.crt',
+          server_key     => '/server.key',
+        }
+        PUPPET
+      end
+    end
+
+    describe x509_certificate('/etc/foreman-proxy/ssl_cert.pem') do
+      it { should be_certificate }
+      # Doesn't have to be valid - can be expired since it's a static resource
+      it { should have_purpose 'server' }
+      its(:issuer) { should eq('CN = Fake LE Intermediate X1') }
+      its(:subject) { should eq('CN = example.partial.solutions') }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_private_key('/etc/foreman-proxy/ssl_key.pem') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate('/etc/foreman-proxy/ssl_cert.pem') }
+    end
+
+    it do
+      foreman_proxy_ca = on default, "cat /etc/foreman-proxy/ssl_ca.pem"
+      default_ca = on default, "cat /root/ssl-build/katello-default-ca.crt"
+      server_ca = on default, "cat /root/ssl-build/katello-server-ca.crt"
+
+      expect(foreman_proxy_ca.output.strip).to include(default_ca.output.strip)
+      expect(foreman_proxy_ca.output.strip).to include(server_ca.output.strip)
+    end
+  end
+
   context 'with deploy false' do
     before(:context) do
       on default, 'rm -rf /root/ssl-build /etc/foreman-proxy'


### PR DESCRIPTION
Let's start with the basics. The Katello installation scenario allows for supplying custom certificates (ones not created by the default CA) from the user so that the public facing sites present a certificate from the users CA provider. The primary location for these to get deployed is Apache, but we also deploy them to the smart-proxy.

For the entire lifecycle, at least from looking back at code, of the custom certificates feature (~7-8 years), we have been deploying the user's custom certificate and private key for the smart-proxy service to use but have been deploying the default CA instead of the CA that signed the server certificates. I think this is generally speaking an incorrect behavior - and things have managed to just work for years now.

As soon as we try to correct this, we will notice certain client based workflows will not work anymore. For example, if a Katello client signed by the default CA presents it's certificates to the smart-proxy for remote execution and REX uses the smart-proxy CA to verify them it will now fail. 

This plays a role in how we think about deploying something new like mosquitto (see https://github.com/theforeman/puppet-foreman_proxy/pull/726) where if we want to re-use the hostname certificates we also need a combined CA certificate so that clients connecting with Katello certificates can do so. 

This change opts to deploy both CA certificates as a chain file.
