### PR TITLE
Fixes #35335 - allow everyone to read the Katello CA certificate

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -93,7 +93,7 @@ class certs::ca (
       source => "${certs::ssl_build_dir}/${server_ca_name}.crt",
       owner  => $owner,
       group  => $group,
-      mode   => '0440',
+      mode   => '0644',
     }
   }
 }


### PR DESCRIPTION
There is nothing secret in that file, and this allows non-root users to
use hammer and friends to check the HTTPS cert of the server.

Fixes: 028f93af283b718752e6263b2732c8c0ce308caf