### PR TITLE
Fix bad requires and old Puppet_X notation

### DIFF
--- a/lib/puppet/provider/keystore/keytool.rb
+++ b/lib/puppet/provider/keystore/keytool.rb
@@ -1,7 +1,7 @@
-require 'puppet_x/certs/provider/keystore'
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x/certs/provider/keystore')
 
 Puppet::Type.type(:keystore).provide(:keytool) do
   commands :keytool => 'keytool'
 
-  include Puppet_X::Certs::Provider::Keystore
+  include PuppetX::Certs::Provider::Keystore
 end

--- a/lib/puppet/provider/truststore/keytool.rb
+++ b/lib/puppet/provider/truststore/keytool.rb
@@ -1,9 +1,9 @@
-require 'puppet_x/certs/provider/keystore'
+require File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x/certs/provider/keystore')
 
 Puppet::Type.type(:truststore).provide(:keytool) do
   commands :keytool => 'keytool'
 
-  include Puppet_X::Certs::Provider::Keystore
+  include PuppetX::Certs::Provider::Keystore
 
   def store
     resource[:truststore]

--- a/lib/puppet/type/cert_key_bundle.rb
+++ b/lib/puppet/type/cert_key_bundle.rb
@@ -1,3 +1,7 @@
+require 'puppet/type/file/owner'
+require 'puppet/type/file/group'
+require 'puppet/type/file/mode'
+
 Puppet::Type.newtype(:cert_key_bundle) do
   desc 'combines a certificate and private key into a single file'
 

--- a/lib/puppet/type/keystore.rb
+++ b/lib/puppet/type/keystore.rb
@@ -1,3 +1,7 @@
+require 'puppet/type/file/owner'
+require 'puppet/type/file/group'
+require 'puppet/type/file/mode'
+
 Puppet::Type.newtype(:keystore) do
   desc 'generates an empty pkcs12 keystore'
 

--- a/lib/puppet/type/nssdb.rb
+++ b/lib/puppet/type/nssdb.rb
@@ -1,3 +1,7 @@
+require 'puppet/type/file/owner'
+require 'puppet/type/file/group'
+require 'puppet/type/file/mode'
+
 Puppet::Type.newtype(:nssdb) do
   desc "Generates an empty NSS database"
 

--- a/lib/puppet/type/private_key.rb
+++ b/lib/puppet/type/private_key.rb
@@ -1,3 +1,7 @@
+require 'puppet/type/file/owner'
+require 'puppet/type/file/group'
+require 'puppet/type/file/mode'
+
 Puppet::Type.newtype(:private_key) do
   desc 'manage a private key'
 

--- a/lib/puppet/type/truststore.rb
+++ b/lib/puppet/type/truststore.rb
@@ -1,3 +1,7 @@
+require 'puppet/type/file/owner'
+require 'puppet/type/file/group'
+require 'puppet/type/file/mode'
+
 Puppet::Type.newtype(:truststore) do
   desc 'Generates an empty pkcs12 truststore'
 

--- a/lib/puppet_x/certs/provider/keystore.rb
+++ b/lib/puppet_x/certs/provider/keystore.rb
@@ -1,4 +1,4 @@
-module Puppet_X
+module PuppetX
   module Certs
     module Provider
       module Keystore


### PR DESCRIPTION
Fixes #388

This also fixes errors I was seeing with `puppet generate types` during deploy. 