### PR TITLE
Fixes #36755 - Set up the correct CA cert for foreman-proxy

### DIFF
--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -107,11 +107,11 @@ class certs::foreman_proxy (
 
     file { $proxy_ca_cert:
       ensure  => file,
-      source  => $default_ca_cert,
+      source  => $server_ca_cert,
       owner   => $owner,
       group   => $group,
       mode    => '0440',
-      require => File[$default_ca_cert],
+      require => File[$server_ca_cert],
     }
 
     certs::keypair { $foreman_proxy_client_cert_name:


### PR DESCRIPTION
The Foreman Proxy certificate is signed by the server_ca_cert, but it previously set up the non-matching default_ca_cert.