### PR TITLE
Deploy the CA password file to ssl build directory

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -23,6 +23,10 @@ class certs::ca (
   String $ca_key_password = $certs::ca_key_password,
   Stdlib::Absolutepath $ca_key_password_file = $certs::ca_key_password_file,
 ) {
+  file { "${certs::pki_dir}/private/${default_ca_name}.pwd":
+    ensure => absent,
+  }
+
   file { $ca_key_password_file:
     ensure    => file,
     content   => $ca_key_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,7 +104,7 @@ class certs (
   $ca_cert = "${pki_dir}/certs/${default_ca_name}.crt"
   $ca_cert_stripped = "${pki_dir}/certs/${default_ca_name}-stripped.crt"
   $ca_key_password = extlib::cache_data('foreman_cache_data', 'ca_key_password', extlib::random_password(24))
-  $ca_key_password_file = "${pki_dir}/private/${default_ca_name}.pwd"
+  $ca_key_password_file = "${ssl_build_dir}/${default_ca_name}.pwd"
 
   $katello_server_ca_cert = "${pki_dir}/certs/${server_ca_name}.crt"
   $katello_default_ca_cert = "${pki_dir}/certs/${default_ca_name}.crt"

--- a/spec/acceptance/certs_spec.rb
+++ b/spec/acceptance/certs_spec.rb
@@ -65,6 +65,14 @@ describe 'certs' do
     describe package("katello-server-ca") do
       it { should_not be_installed }
     end
+
+    describe file('/root/ssl-build/katello-default-ca.pwd') do
+      it { should exist }
+    end
+
+    describe file('/etc/pki/katello/private/katello-default-ca.pwd') do
+      it { should_not exist }
+    end
   end
 
   context 'with deploy false' do


### PR DESCRIPTION
As the pki_dir is intended for deployment rather than generation, and the CA password file is needed primarily for certificate generation it should reside in the build directory.