### PR TITLE
Drop RPMs from being included in tarball

### DIFF
--- a/manifests/tar_create.pp
+++ b/manifests/tar_create.pp
@@ -12,16 +12,14 @@ define certs::tar_create (
   Stdlib::Absolutepath $path = $title,
   Stdlib::Fqdn $foreman_proxy_fqdn = $certs::foreman_proxy_content::foreman_proxy_fqdn,
 ) {
-  $ca_rpms = 'ssl-build/*.noarch.rpm'
   $ca_certificates = 'ssl-build/*.crt'
 
-  $foreman_proxy_certificate_rpms = "ssl-build/${foreman_proxy_fqdn}/*.noarch.rpm"
   $foreman_proxy_certificates = "ssl-build/${foreman_proxy_fqdn}/*.crt"
   $foreman_proxy_keys = "ssl-build/${foreman_proxy_fqdn}/*.key"
 
   exec { "generate ${path}":
     cwd     => '/root',
     path    => ['/usr/bin', '/bin'],
-    command => "tar -caf ${path} ${ca_rpms} ${ca_certificates} ${foreman_proxy_certificate_rpms} ${foreman_proxy_certificates} ${foreman_proxy_keys}",
+    command => "tar -caf ${path} ${ca_certificates} ${foreman_proxy_certificates} ${foreman_proxy_keys}",
   }
 }

--- a/spec/acceptance/foreman_proxy_content_spec.rb
+++ b/spec/acceptance/foreman_proxy_content_spec.rb
@@ -26,15 +26,8 @@ describe 'certs::foreman_proxy_content' do
 
     let(:expected_files_in_tar) do
       [
-        'ssl-build/katello-default-ca-1.0-1.noarch.rpm',
-        'ssl-build/katello-server-ca-1.0-1.noarch.rpm',
         'ssl-build/katello-default-ca.crt',
         'ssl-build/katello-server-ca.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache-1.0-1.noarch.rpm',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client-1.0-1.noarch.rpm',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-1.0-1.noarch.rpm',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client-1.0-1.noarch.rpm',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client-1.0-1.noarch.rpm',
         'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.crt',
         'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.crt',
         'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.crt',


### PR DESCRIPTION
These were kept in for N-1 support when we first switched away from using RPMs for deployment. Enough release have passed that we can drop this.