### PR TITLE
Bump major version to reflect next release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-certs",
-  "version": "16.0.2",
+  "version": "17.0.0",
   "author": "katello",
   "summary": "Deploys CA and required certs for a Foreman and Katello installation.",
   "license": "GPL-3.0+",


### PR DESCRIPTION
There have been breaking changes and this reflects that. It allows creating a stable branch without immediately releasing all changes.