### PR TITLE
Handle more unknown password errors

### DIFF
--- a/lib/puppet_x/certs/provider/keystore.rb
+++ b/lib/puppet_x/certs/provider/keystore.rb
@@ -20,7 +20,7 @@ module PuppetX
               '-storepass:file', resource[:password_file],
             )
           rescue Puppet::ExecutionFailure => e
-            if e.message.include?('java.security.UnrecoverableKeyException')
+            if e.message.include?('java.security.UnrecoverableKeyException') || e.message.include?('keystore password was incorrect')
               Puppet.debug("Invalid password for #{store}")
               return false
             else


### PR DESCRIPTION
When using keytool on a truststore the error is different than on a keystore.

Fixes: 6fea0bbb4143ca439cff01bf9f0e54cf88140d10 ("Support changing passwords on keystores & truststores")