### PR TITLE
Create pki_dir structure only when deployed

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -85,6 +85,8 @@ class certs::ca (
   }
 
   if $deploy {
+    include certs::config
+
     # Ensure CA key deployed to /etc/pki/katello/private no longer exists
     # The CA key is not used by anything from this directory and does not need to be deployed
     file { $ca_key:

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -27,6 +27,13 @@ class certs::ca (
     ensure => absent,
   }
 
+  file { $ssl_build_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0700',
+  }
+
   file { $ca_key_password_file:
     ensure    => file,
     content   => $ca_key_password,

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -47,7 +47,7 @@ class certs::ca (
     generate      => $generate,
     deploy        => false,
     password_file => $ca_key_password_file,
-    build_dir     => $certs::ssl_build_dir,
+    build_dir     => $ssl_build_dir,
   }
   $default_ca = Ca[$default_ca_name]
 
@@ -57,15 +57,15 @@ class certs::ca (
       generate      => $generate,
       deploy        => false,
       custom_pubkey => $certs::server_ca_cert,
-      build_dir     => $certs::ssl_build_dir,
+      build_dir     => $ssl_build_dir,
     }
   } else {
     ca { $server_ca_name:
       ensure        => present,
       generate      => $generate,
       deploy        => false,
-      custom_pubkey => "${certs::ssl_build_dir}/${default_ca_name}.crt",
-      build_dir     => $certs::ssl_build_dir,
+      custom_pubkey => "${ssl_build_dir}/${default_ca_name}.crt",
+      build_dir     => $ssl_build_dir,
     }
   }
 
@@ -86,7 +86,7 @@ class certs::ca (
 
     file { $certs::katello_default_ca_cert:
       ensure => file,
-      source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
+      source => "${ssl_build_dir}/${default_ca_name}.crt",
       owner  => 'root',
       group  => 'root',
       mode   => '0644',
@@ -94,7 +94,7 @@ class certs::ca (
 
     file { $katello_server_ca_cert:
       ensure => file,
-      source => "${certs::ssl_build_dir}/${server_ca_name}.crt",
+      source => "${ssl_build_dir}/${server_ca_name}.crt",
       owner  => $owner,
       group  => $group,
       mode   => '0644',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,13 +4,6 @@ class certs::config (
   Stdlib::Absolutepath $pki_dir = $certs::pki_dir,
   String $group = $certs::group,
 ) {
-  file { $certs::ssl_build_dir:
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0700',
-  }
-
   file { $pki_dir:
     ensure => directory,
     owner  => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,11 +116,9 @@ class certs (
   }
 
   contain certs::install
-  contain certs::config
   contain certs::ca
 
   Class['certs::install'] ->
-  Class['certs::config'] ->
   Class['certs::ca']
 
   $default_ca = $certs::ca::default_ca

--- a/manifests/keypair.pp
+++ b/manifests/keypair.pp
@@ -15,6 +15,8 @@ define certs::keypair (
   Boolean $key_decrypt = false,
   Optional[Stdlib::Absolutepath] $key_password_file = undef,
 ) {
+  include certs::config
+
   private_key { $key_file:
     ensure        => $key_ensure,
     source        => "${source_dir}/${title}.key",

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -41,6 +41,8 @@ class certs::qpid (
     $nss_db_dir = $certs::ssltools::nssdb::nss_db_dir
     $nss_db_password_file = $certs::ssltools::nssdb::nss_db_password_file
 
+    include certs::config
+
     $client_cert            = "${pki_dir}/certs/${qpid_cert_name}.crt"
     $client_key             = "${pki_dir}/private/${qpid_cert_name}.key"
 


### PR DESCRIPTION
This is an alternative to https://github.com/theforeman/puppet-certs/pull/417. The goal is to only create the `/etc/pki` directory on deployments, because on then it's needed.