### PR TITLE
Fix some RuboCop flagged issues for Puppet 8 support

### DIFF
--- a/lib/puppet/provider/ca/katello_ssl_tool.rb
+++ b/lib/puppet/provider/ca/katello_ssl_tool.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:ca).provide(:katello_ssl_tool, :parent => Puppet::Provider::K
   end
 
   def deploy!
-    if File.exists?(rpmfile)
+    if File.exist?(rpmfile)
       # the rpm is available locally on the file system
       rpm('-Uvh', '--force', rpmfile)
     else

--- a/lib/puppet/provider/katello_ssl_tool.rb
+++ b/lib/puppet/provider/katello_ssl_tool.rb
@@ -20,7 +20,7 @@ module Puppet::Provider::KatelloSslTool
 
     def destroy
       files_to_deploy.each do |file|
-        File.delete(file) if File.exist?(file)
+        FileUtils.rm_f(file)
       end
 
       output = execute([:rpm, '-q', rpmfile_base_name], failonfail: false)
@@ -53,9 +53,7 @@ module Puppet::Provider::KatelloSslTool
     end
 
     def generate!
-      if File.exists?(update_file)
-        File.delete(update_file)
-      end
+      FileUtils.rm_f(update_file)
     end
 
     def generate?
@@ -189,7 +187,7 @@ module Puppet::Provider::KatelloSslTool
     end
 
     def destroy
-      File.delete(resource[:path]) if File.exist?(resource[:path])
+      FileUtils.rm_f(resource[:path])
     end
 
     protected

--- a/lib/puppet/provider/katello_ssl_tool.rb
+++ b/lib/puppet/provider/katello_ssl_tool.rb
@@ -59,7 +59,7 @@ module Puppet::Provider::KatelloSslTool
     def generate?
       return false unless resource[:generate]
       return true if resource[:regenerate]
-      return true if File.exists?(update_file)
+      return true if File.exist?(update_file)
       return files_to_generate.any? { |file| ! File.exist?(file) }
     end
 
@@ -79,7 +79,7 @@ module Puppet::Provider::KatelloSslTool
     end
 
     def deploy!
-      if File.exists?(rpmfile)
+      if File.exist?(rpmfile)
         if(system("rpm -q #{rpmfile_base_name} &>/dev/null"))
           rpm('-e', rpmfile_base_name)
         end
@@ -91,7 +91,7 @@ module Puppet::Provider::KatelloSslTool
     end
 
     def needs_deploy?
-      if File.exists?(rpmfile)
+      if File.exist?(rpmfile)
         # the installed version doesn't match the rpmfile
         !system("rpm --verify -p #{rpmfile} &>/dev/null")
       else
@@ -177,8 +177,8 @@ module Puppet::Provider::KatelloSslTool
     commands :openssl => 'openssl'
 
     def exists?
-      return false unless File.exists?(resource[:path])
-      return false unless File.exists?(source_path)
+      return false unless File.exist?(resource[:path])
+      return false unless File.exist?(source_path)
       expected_content_processed == current_content
     end
 

--- a/lib/puppet/provider/key_bundle/katello_ssl_tool.rb
+++ b/lib/puppet/provider/key_bundle/katello_ssl_tool.rb
@@ -3,9 +3,9 @@ require File.expand_path('../../katello_ssl_tool', __FILE__)
 Puppet::Type.type(:key_bundle).provide(:katello_ssl_tool, :parent => Puppet::Provider::KatelloSslTool::CertFile) do
 
   def exists?
-    return false unless File.exists?(resource[:path])
-    return false unless File.exists?(privkey_source_path)
-    return false unless File.exists?(pubkey_source_path)
+    return false unless File.exist?(resource[:path])
+    return false unless File.exist?(privkey_source_path)
+    return false unless File.exist?(pubkey_source_path)
     expected_content_processed == current_content
   end
 

--- a/lib/puppet/provider/privkey/katello_ssl_tool.rb
+++ b/lib/puppet/provider/privkey/katello_ssl_tool.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:privkey).provide(:katello_ssl_tool, :parent => Puppet::Provid
                 '-passin', "file:#{resource[:password_file]}")
         File.read(tmp_file)
       ensure
-        File.delete(tmp_file) if File.exists?(tmp_file)
+        FileUtils.rm_f(tmp_file)
       end
     else
       super

--- a/spec/classes/certs_qpid_router_client_spec.rb
+++ b/spec/classes/certs_qpid_router_client_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 describe 'certs::qpid_router::client' do
   on_supported_os.each do |os, os_facts|
-    let :facts do
-      os_facts
-    end
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
 
-    describe 'with default parameters' do
-      it { should compile.with_all_deps }
+      describe 'with default parameters' do
+        it { should compile.with_all_deps }
+      end
     end
   end
 end

--- a/spec/classes/certs_qpid_router_server_spec.rb
+++ b/spec/classes/certs_qpid_router_server_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 describe 'certs::qpid_router::server' do
   on_supported_os.each do |os, os_facts|
-    let :facts do
-      os_facts
-    end
+    context "on #{os}" do
+      let :facts do
+        os_facts
+      end
 
-    describe 'with default parameters' do
-      it { should compile.with_all_deps }
+      describe 'with default parameters' do
+        it { should compile.with_all_deps }
+      end
     end
   end
 end


### PR DESCRIPTION
https://github.com/theforeman/puppet-certs/pull/412 was merged with failing CI. I used auto-merge, but there is a required check. That did not pass and still it was merged. This PR fixes the failures and makes Puppet 8 work. Technically they're really Ruby 3 fixes, but that's what Puppet 8 ships.