### PR TITLE
Use automatic compression based on file path for tar

### DIFF
--- a/manifests/tar_create.pp
+++ b/manifests/tar_create.pp
@@ -22,6 +22,6 @@ define certs::tar_create (
   exec { "generate ${path}":
     cwd     => '/root',
     path    => ['/usr/bin', '/bin'],
-    command => "tar -czf ${path} ${ca_rpms} ${ca_certificates} ${foreman_proxy_certificate_rpms} ${foreman_proxy_certificates} ${foreman_proxy_keys}",
+    command => "tar -caf ${path} ${ca_rpms} ${ca_certificates} ${foreman_proxy_certificate_rpms} ${foreman_proxy_certificates} ${foreman_proxy_keys}",
   }
 }


### PR DESCRIPTION
This way users can pass .tar.xz to get XZ compression too. One side effect is that by default we won't compress anymore since the file extension is .tar. On the other hand, it's less confusing for users that you have a .tar extension which should be .tar.gz.

This was noted in https://bugzilla.redhat.com/show_bug.cgi?id=1874045#c5. Right now this is a draft because I think we first need to have a discussion on whether this is correct. Note `certs::tar_extract` already has `-a` so it should pick it up already.