### PR TITLE
Fixes #37384 - properly pass fips=false when checking keystore

### DIFF
--- a/lib/puppet_x/certs/provider/keystore.rb
+++ b/lib/puppet_x/certs/provider/keystore.rb
@@ -18,6 +18,7 @@ module PuppetX
               '-list',
               '-keystore', store,
               '-storepass:file', resource[:password_file],
+              '-J-Dcom.redhat.fips=false',
             )
           rescue Puppet::ExecutionFailure => e
             if e.message.include?('java.security.UnrecoverableKeyException') || e.message.include?('keystore password was incorrect')


### PR DESCRIPTION
In a FIPS-enabled environment, calling `keytool -list` with a wrong password doesn't yield an error, unless we also pass `fips=false` like we do when creating the keystore:

    # keytool -list -keystore ./store -storepass wrong-password
    Keystore type: PKCS11
    Keystore provider: SunPKCS11-NSS-FIPS

    Your keystore contains 0 entries

Passing `fips=false` makes it correctly raise the expected exception:

    # keytool -list -keystore ./store -storepass wrong-password -J-Dcom.redhat.fips=false
    keytool error: java.io.IOException: keystore password was incorrect

Fixes: 6fea0bbb4143ca439cff01bf9f0e54cf88140d10
(cherry picked from commit b9667a02bebf6cce0b96fbd631ce34fb27c325ec)