### PR TITLE
Ensure hostname directory exists when copying server cert

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -72,6 +72,16 @@ class certs::apache (
   $apache_cert_path = "${certs::ssl_build_dir}/${hostname}/${apache_cert_name}"
 
   if $server_cert {
+    ensure_resource(
+      'file',
+      "${certs::ssl_build_dir}/${hostname}",
+      {
+        'ensure' => directory,
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0750',
+      }
+    )
     file { "${apache_cert_path}.crt":
       ensure => file,
       source => $server_cert,

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -40,6 +40,16 @@ class certs::foreman_proxy (
   $proxy_cert_path = "${certs::ssl_build_dir}/${hostname}/${proxy_cert_name}"
 
   if $server_cert {
+    ensure_resource(
+      'file',
+      "${certs::ssl_build_dir}/${hostname}",
+      {
+        'ensure' => directory,
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0750',
+      }
+    )
     file { "${proxy_cert_path}.crt":
       ensure => file,
       source => $server_cert,

--- a/spec/acceptance/apache_spec.rb
+++ b/spec/acceptance/apache_spec.rb
@@ -131,4 +131,46 @@ describe 'certs::apache' do
       it { should_not exist }
     end
   end
+
+  context 'with custom certificates fresh' do
+    before(:context) do
+      ['crt', 'key'].each do |ext|
+        source_path = "fixtures/example.partial.solutions.#{ext}"
+        dest_path = "/server.#{ext}"
+        scp_to(hosts, source_path, dest_path)
+      end
+
+      on hosts, 'rm -rf /root/ssl-build'
+    end
+
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { '::certs::apache':
+          server_cert => '/server.crt',
+          server_key  => '/server.key',
+        }
+        PUPPET
+      end
+    end
+
+    describe x509_certificate('/etc/pki/katello/certs/katello-apache.crt') do
+      it { should be_certificate }
+      # Doesn't have to be valid - can be expired since it's a static resource
+      it { should have_purpose 'server' }
+      its(:issuer) { should match_without_whitespace(/CN = Fake LE Intermediate X1/) }
+      its(:subject) { should match_without_whitespace(/CN = example.partial.solutions/) }
+      its(:keylength) { should be >= 2048 }
+    end
+
+    describe x509_private_key('/etc/pki/katello/private/katello-apache.key') do
+      it { should_not be_encrypted }
+      it { should be_valid }
+      it { should have_matching_certificate('/etc/pki/katello/certs/katello-apache.crt') }
+    end
+
+    describe package("#{fact('fqdn')}-apache") do
+      it { should_not be_installed }
+    end
+  end
 end


### PR DESCRIPTION
There is a pattern here between Apache and Foreman Proxy certificates, and I do think this warrants further re-factoring to simplify and unify the certificate generation and separate it from deployment. That work is more than should be undertaken to fix this bug I introduced.