### PR TITLE
Move keystore and trustore password files

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -49,8 +49,8 @@ class certs::candlepin (
 
   $keystore_password = extlib::cache_data('foreman_cache_data', $keystore_password_file, extlib::random_password(32))
   $truststore_password = extlib::cache_data('foreman_cache_data', $truststore_password_file, extlib::random_password(32))
-  $keystore_password_path = "${pki_dir}/${keystore_password_file}"
-  $truststore_password_path = "${pki_dir}/${truststore_password_file}"
+  $keystore_password_path = "${certs::candlepin_certs_dir}/${keystore_password_file}"
+  $truststore_password_path = "${certs::candlepin_certs_dir}/${truststore_password_file}"
   $client_key = $certs::foreman::client_key
   $client_cert = $certs::foreman::client_cert
   $alias = 'candlepin-ca'
@@ -123,6 +123,14 @@ class certs::candlepin (
       ensure        => present,
       password_file => $truststore_password_path,
       certificate   => $client_cert,
+    }
+
+    file { "${pki_dir}/${keystore_password_file}":
+      ensure => absent,
+    }
+
+    file { "${pki_dir}/${truststore_password_file}":
+      ensure => absent,
     }
   }
 }

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper_acceptance'
 describe 'certs' do
   fqdn = fact('fqdn')
 
-  keystore_password_file = '/etc/pki/katello/keystore_password-file'
-  truststore_password_file = '/etc/pki/katello/truststore_password-file'
+  keystore_password_file = '/etc/candlepin/certs/keystore_password-file'
+  truststore_password_file = '/etc/candlepin/certs/truststore_password-file'
 
   before(:all) do
     on default, 'rm -rf /root/ssl-build'
@@ -66,6 +66,14 @@ describe 'certs' do
     end
 
     describe file('/etc/pki/katello/private/katello-tomcat.key') do
+      it { should_not exist }
+    end
+
+    describe file('/etc/pki/katello/keystore_password-file') do
+      it { should_not exist }
+    end
+
+    describe file('/etc/pki/katello/truststore_password-file') do
       it { should_not exist }
     end
 


### PR DESCRIPTION
Change to storing the password files in `/etc/candlepin/certs` co-located with the trustore and keystore themselves rather than storing them arbitrarily in their current location. This helps bring the Candlepin SSL configuration together.