### PR TITLE
Make deploying client bundle certificate optional

### DIFF
--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -32,6 +32,7 @@ class certs::foreman_proxy (
   String $owner = 'root',
   Stdlib::Filemode $private_key_mode = '0440',
   Stdlib::Filemode $public_key_mode = '0444',
+  Enum['present', 'absent'] $client_bundle_ensure = 'present',
 ) inherits certs {
   $proxy_cert_name = "${hostname}-foreman-proxy"
   $foreman_proxy_client_cert_name = "${hostname}-foreman-proxy-client"
@@ -152,7 +153,7 @@ class certs::foreman_proxy (
     }
 
     cert_key_bundle { $foreman_proxy_ssl_client_bundle:
-      ensure       => present,
+      ensure       => $client_bundle_ensure,
       certificate  => "${certs::ssl_build_dir}/${hostname}/${foreman_proxy_client_cert_name}.crt",
       private_key  => "${certs::ssl_build_dir}/${hostname}/${foreman_proxy_client_cert_name}.key",
       force_pkcs_1 => true,

--- a/spec/acceptance/foreman_proxy_spec.rb
+++ b/spec/acceptance/foreman_proxy_spec.rb
@@ -272,4 +272,57 @@ describe 'certs::foreman_proxy' do
       it { should_not exist }
     end
   end
+
+  context 'with include_client_bundle absent' do
+    before(:context) do
+      on default, 'rm -rf /root/ssl-build /etc/foreman-proxy /etc/pki/katello'
+    end
+
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+          file { '/etc/foreman-proxy':
+            ensure => directory,
+          }
+
+          group { 'foreman-proxy':
+            ensure => present,
+            system => true,
+          }
+
+          class { 'certs::foreman_proxy':
+            client_bundle_ensure => 'absent',
+          }
+        PUPPET
+      end
+    end
+
+    describe file('/etc/foreman-proxy/ssl_cert.pem') do
+      it { should exist }
+    end
+
+    describe file('/etc/foreman-proxy/ssl_key.pem') do
+      it { should exist }
+    end
+
+    describe file('/etc/foreman-proxy/ssl_ca.pem') do
+      it { should exist }
+    end
+
+    describe file('/etc/foreman-proxy/foreman_ssl_cert.pem') do
+      it { should exist }
+    end
+
+    describe file('/etc/foreman-proxy/foreman_ssl_key.pem') do
+      it { should exist }
+    end
+
+    describe file('/etc/foreman-proxy/foreman_ssl_ca.pem') do
+      it { should exist }
+    end
+
+    describe file("/etc/pki/katello/private/#{fqdn}/#{fqdn}-foreman-proxy-client-bundle.pem") do
+      it { should_not exist }
+    end
+  end
 end


### PR DESCRIPTION
Currently we deploy this certificate in all deployments but it should only be deployed onto a foreman-proxy where reverse proxy is present. It is useless and unused on a Foreman deployment. This keeps the default behaviour by defaulting to 'present' but provides a way to set this to false in `puppet-foreman_proxy_content` (PR to follow).