### PR TITLE
Fixes #37695 - Prevent server ca from being overwritten with default ca

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -55,11 +55,12 @@ class certs::ca (
     }
   } else {
     file { $server_ca_path:
-      ensure => file,
-      source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
+      ensure  => file,
+      source  => "${certs::ssl_build_dir}/${default_ca_name}.crt",
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      replace => false,
     }
   }
 


### PR DESCRIPTION
As stated in #456 I'd propose to prevent the replacement of an existing server ca.