### PR TITLE
Fixes #37817: Only copy server CA in build root if generate is true

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -45,25 +45,25 @@ class certs::ca (
     build_dir     => $certs::ssl_build_dir,
   }
 
-  if $certs::server_ca_cert {
-    file { $server_ca_path:
-      ensure => file,
-      source => $certs::server_ca_cert,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
-  } else {
-    file { $server_ca_path:
-      ensure => file,
-      source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
-  }
-
   if $generate {
+    if $certs::server_ca_cert {
+      file { $server_ca_path:
+        ensure => file,
+        source => $certs::server_ca_cert,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+      }
+    } else {
+      file { $server_ca_path:
+        ensure => file,
+        source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+      }
+    }
+
     file { "${certs::ssl_build_dir}/KATELLO-TRUSTED-SSL-CERT":
       ensure  => link,
       target  => $server_ca_path,

--- a/spec/acceptance/certs_spec.rb
+++ b/spec/acceptance/certs_spec.rb
@@ -151,4 +151,115 @@ describe 'certs' do
       its(:keylength) { should be >= 2048 }
     end
   end
+
+  context 'with tar file' do
+    before(:context) do
+      ['crt', 'key'].each do |ext|
+        source_path = "fixtures/example.partial.solutions.#{ext}"
+        dest_path = "/server.#{ext}"
+        scp_to(hosts, source_path, dest_path)
+      end
+    end
+
+    context 'with default ca' do
+      before(:context) do
+        manifest = <<~PUPPET
+          class { 'certs':
+            generate => true,
+            deploy   => false,
+          }
+
+          class { 'certs::foreman_proxy_content':
+            foreman_proxy_fqdn => 'foreman-proxy.example.com',
+            certs_tar          => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+
+        apply_manifest(manifest, catch_failures: true)
+
+        on default, 'rm -rf /root/ssl-build'
+      end
+
+      describe 'deploy certificates' do
+        manifest = <<-PUPPET
+          class { 'certs':
+            tar_file => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+        # tar extraction is not idempotent
+        it { apply_manifest(manifest, catch_failures: true) }
+      end
+
+      describe 'default and server ca certs match' do
+        it { expect(file('/etc/pki/katello/certs/katello-default-ca.crt').content).to eq(file('/etc/pki/katello/certs/katello-server-ca.crt').content) }
+      end
+
+      describe x509_certificate('/etc/pki/katello/certs/katello-default-ca.crt') do
+        it { should be_certificate }
+        it { should be_valid }
+        it { should have_purpose 'SSL server CA' }
+        its(:issuer) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:subject) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:keylength) { should be >= 4096 }
+      end
+    end
+
+    context 'with custom certificates' do
+      before(:context) do
+        manifest = <<~PUPPET
+          class { 'certs':
+            server_cert    => '/server.crt',
+            server_key     => '/server.key',
+            server_ca_cert => '/server-ca.crt',
+            generate       => true,
+            deploy         => false,
+          }
+
+          class { 'certs::foreman_proxy_content':
+            foreman_proxy_fqdn => 'foreman-proxy.example.com',
+            certs_tar          => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+
+        apply_manifest(manifest, catch_failures: true)
+
+        on default, 'rm -rf /root/ssl-build'
+      end
+
+      describe 'deploy certificates' do
+        manifest = <<-PUPPET
+          class { 'certs':
+            generate => false,
+            tar_file => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+        # tar extraction is not idempotent
+        it { apply_manifest(manifest, catch_failures: true) }
+      end
+
+      describe 'default and server ca certs match' do
+        it { expect(file('/etc/pki/katello/certs/katello-default-ca.crt').content).not_to eq(file('/etc/pki/katello/certs/katello-server-ca.crt').content) }
+      end
+
+      describe x509_certificate('/etc/pki/katello/certs/katello-default-ca.crt') do
+        it { should be_certificate }
+        it { should be_valid }
+        it { should have_purpose 'SSL server CA' }
+        its(:issuer) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:subject) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:keylength) { should be >= 4096 }
+      end
+
+      describe x509_certificate('/etc/pki/katello/certs/katello-server-ca.crt') do
+        it { should be_certificate }
+        it { should be_valid }
+        it { should have_purpose 'SSL server CA' }
+        # These don't match since we only configure it with the intermediate
+        # and not the actual root
+        its(:issuer) { should match_without_whitespace(/CN = Fake LE Root X1/) }
+        its(:subject) { should match_without_whitespace(/CN = Fake LE Intermediate X1/) }
+        its(:keylength) { should be >= 2048 }
+      end
+    end
+  end
 end

--- a/spec/acceptance/foreman_proxy_content_spec.rb
+++ b/spec/acceptance/foreman_proxy_content_spec.rb
@@ -5,11 +5,26 @@ describe 'certs::foreman_proxy_content' do
     on default, 'rm -rf /root/ssl-build'
   end
 
-  context 'with default parameters' do
-    before(:context) do
-      apply_manifest('include certs', catch_failures: true)
+  let(:expected_files_in_tar) do
+    [
+      'ssl-build/katello-default-ca.crt',
+      'ssl-build/katello-server-ca.crt',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.crt',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.crt',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.crt',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy.crt',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client.crt',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.key',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.key',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.key',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy.key',
+      'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client.key',
+    ]
+  end
 
-      pp = <<-PUPPET
+  context 'with default CA' do
+    before(:context) do
+      manifest = <<~PUPPET
         class { 'certs':
           generate => true,
           deploy   => false,
@@ -21,29 +36,55 @@ describe 'certs::foreman_proxy_content' do
         }
       PUPPET
 
-      apply_manifest(pp, catch_failures: true)
-    end
-
-    let(:expected_files_in_tar) do
-      [
-        'ssl-build/katello-default-ca.crt',
-        'ssl-build/katello-server-ca.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client.crt',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-apache.key',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-client.key',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy-client.key',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-foreman-proxy.key',
-        'ssl-build/foreman-proxy.example.com/foreman-proxy.example.com-puppet-client.key',
-      ]
+      apply_manifest(manifest, catch_failures: true)
     end
 
     describe tar('/root/foreman-proxy.example.com.tar.gz') do
       it { should exist }
       its(:contents) { should match_array(expected_files_in_tar) }
+    end
+
+    describe 'default and server ca certs match' do
+      it { expect(file('/root/ssl-build/katello-default-ca.crt').content).to eq(file('/root/ssl-build/katello-server-ca.crt').content) }
+    end
+  end
+
+  context 'with server certificates' do
+    before(:context) do
+      certs = {
+        'fixtures/example.partial.solutions.crt' => '/server.crt',
+        'fixtures/example.partial.solutions.key' => '/server.key',
+        'fixtures/example.partial.solutions-chain.pem' => '/server-ca.crt',
+      }
+      certs.each do |source_path, dest_path|
+        scp_to(hosts, source_path, dest_path)
+      end
+
+      manifest = <<~PUPPET
+        class { 'certs':
+          server_cert    => '/server.crt',
+          server_key     => '/server.key',
+          server_ca_cert => '/server-ca.crt',
+          generate       => true,
+          deploy         => false,
+        }
+
+        class { 'certs::foreman_proxy_content':
+          foreman_proxy_fqdn => 'foreman-proxy.example.com',
+          certs_tar          => '/root/foreman-proxy.example.com.tar.gz',
+        }
+      PUPPET
+
+      apply_manifest(manifest, catch_failures: true)
+    end
+
+    describe tar('/root/foreman-proxy.example.com.tar.gz') do
+      it { should exist }
+      its(:contents) { should match_array(expected_files_in_tar) }
+    end
+
+    describe 'default and server ca certs differ' do
+      it { expect(file('/root/ssl-build/katello-default-ca.crt').content).not_to eq(file('/root/ssl-build/katello-server-ca.crt').content) }
     end
   end
 end


### PR DESCRIPTION
Alternative to https://github.com/theforeman/puppet-certs/pull/461. This does include the tests from 461, but not the re-factorings. I wanted to have as crisp of a solution to the regression as possible. The re-factoring, which I like, we can layer on top of the fix afterward.

If you rewind to https://github.com/theforeman/puppet-certs/commit/433dadc5ec41c2477fc6a04e056ca061fd818980, prior to this change, the `ca` resource was used to perform the copying to the server CA in the build root. This resource had the `generate` parameter built into it. This is what prevented the current regression from happening in the old design.  When deploying a foreman-proxy-content scenario in the installer, we are supplying all the certificates in the tarball. Therefore no generation needs to occur. Which we can see as the case by looking at the answers file (https://github.com/theforeman/foreman-installer/blob/develop/config/foreman-proxy-content-answers.yaml#L13C1-L14C1):

```
certs:
  generate: false
```

I think this is the correct solution at this point in time, as it restores the prior behavior and fixes the issues (as evidenced by the reproducer tests -- thanks @ekohl). 

This issue has given me some ideas on how this could be improved in upcoming releases through some re-factoring and re-design.