### PR TITLE
Ensure KATELLO-TRUSTED-SSL-CERT is absent

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -65,9 +65,7 @@ class certs::ca (
     }
 
     file { "${certs::ssl_build_dir}/KATELLO-TRUSTED-SSL-CERT":
-      ensure  => link,
-      target  => $server_ca_path,
-      require => File[$server_ca_path],
+      ensure  => absent,
     }
   }
 


### PR DESCRIPTION
This file has been unused for a long time and removal simplifies the module.