### PR TITLE
Fixes #37817: Only copy server CA in build root if generate is true

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -49,25 +49,25 @@ class certs::ca (
     build_dir     => $certs::ssl_build_dir,
   }
 
-  if $certs::server_ca_cert {
-    file { $server_ca_path:
-      ensure => file,
-      source => $certs::server_ca_cert,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
-  } else {
-    file { $server_ca_path:
-      ensure => file,
-      source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
-  }
-
   if $generate {
+    if $certs::server_ca_cert {
+      file { $server_ca_path:
+        ensure => file,
+        source => $certs::server_ca_cert,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+      }
+    } else {
+      file { $server_ca_path:
+        ensure => file,
+        source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+      }
+    }
+
     file { "${certs::ssl_build_dir}/KATELLO-TRUSTED-SSL-CERT":
       ensure  => link,
       target  => $server_ca_path,

--- a/spec/acceptance/certs_spec.rb
+++ b/spec/acceptance/certs_spec.rb
@@ -151,4 +151,115 @@ describe 'certs' do
       its(:keylength) { should be >= 2048 }
     end
   end
+
+  context 'with tar file' do
+    before(:context) do
+      ['crt', 'key'].each do |ext|
+        source_path = "fixtures/example.partial.solutions.#{ext}"
+        dest_path = "/server.#{ext}"
+        scp_to(hosts, source_path, dest_path)
+      end
+    end
+
+    context 'with default ca' do
+      before(:context) do
+        manifest = <<~PUPPET
+          class { 'certs':
+            generate => true,
+            deploy   => false,
+          }
+
+          class { 'certs::foreman_proxy_content':
+            foreman_proxy_fqdn => 'foreman-proxy.example.com',
+            certs_tar          => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+
+        apply_manifest(manifest, catch_failures: true)
+
+        on default, 'rm -rf /root/ssl-build'
+      end
+
+      describe 'deploy certificates' do
+        manifest = <<-PUPPET
+          class { 'certs':
+            tar_file => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+        # tar extraction is not idempotent
+        it { apply_manifest(manifest, catch_failures: true) }
+      end
+
+      describe 'default and server ca certs match' do
+        it { expect(file('/etc/pki/katello/certs/katello-default-ca.crt').content).to eq(file('/etc/pki/katello/certs/katello-server-ca.crt').content) }
+      end
+
+      describe x509_certificate('/etc/pki/katello/certs/katello-default-ca.crt') do
+        it { should be_certificate }
+        it { should be_valid }
+        it { should have_purpose 'SSL server CA' }
+        its(:issuer) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:subject) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:keylength) { should be >= 4096 }
+      end
+    end
+
+    context 'with custom certificates' do
+      before(:context) do
+        manifest = <<~PUPPET
+          class { 'certs':
+            server_cert    => '/server.crt',
+            server_key     => '/server.key',
+            server_ca_cert => '/server-ca.crt',
+            generate       => true,
+            deploy         => false,
+          }
+
+          class { 'certs::foreman_proxy_content':
+            foreman_proxy_fqdn => 'foreman-proxy.example.com',
+            certs_tar          => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+
+        apply_manifest(manifest, catch_failures: true)
+
+        on default, 'rm -rf /root/ssl-build'
+      end
+
+      describe 'deploy certificates' do
+        manifest = <<-PUPPET
+          class { 'certs':
+            generate => false,
+            tar_file => '/root/foreman-proxy.example.com.tar.gz',
+          }
+        PUPPET
+        # tar extraction is not idempotent
+        it { apply_manifest(manifest, catch_failures: true) }
+      end
+
+      describe 'default and server ca certs match' do
+        it { expect(file('/etc/pki/katello/certs/katello-default-ca.crt').content).not_to eq(file('/etc/pki/katello/certs/katello-server-ca.crt').content) }
+      end
+
+      describe x509_certificate('/etc/pki/katello/certs/katello-default-ca.crt') do
+        it { should be_certificate }
+        it { should be_valid }
+        it { should have_purpose 'SSL server CA' }
+        its(:issuer) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:subject) { should match_without_whitespace(/C = US, ST = North Carolina, L = Raleigh, O = Katello, OU = SomeOrgUnit, CN = #{fact('fqdn')}/) }
+        its(:keylength) { should be >= 4096 }
+      end
+
+      describe x509_certificate('/etc/pki/katello/certs/katello-server-ca.crt') do
+        it { should be_certificate }
+        it { should be_valid }
+        it { should have_purpose 'SSL server CA' }
+        # These don't match since we only configure it with the intermediate
+        # and not the actual root
+        its(:issuer) { should match_without_whitespace(/CN = Fake LE Root X1/) }
+        its(:subject) { should match_without_whitespace(/CN = Fake LE Intermediate X1/) }
+        its(:keylength) { should be >= 2048 }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes: 433dadc5ec41 ("Copy the server CA certificate with file resource")
(cherry picked from commit 15a3cc2c81ecf976380f99143d83741e565d95f0)