### PR TITLE
Merge if/else branch into a single resource declaration & introduce $default_ca_path

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -47,22 +47,12 @@ class certs::ca (
   }
 
   if $generate {
-    if $certs::server_ca_cert {
-      file { $server_ca_path:
-        ensure => file,
-        source => $certs::server_ca_cert,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0644',
-      }
-    } else {
-      file { $server_ca_path:
-        ensure => file,
-        source => $default_ca_path,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0644',
-      }
+    file { $server_ca_path:
+      ensure => file,
+      source => pick($certs::server_ca_cert, $default_ca_path),
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
     }
 
     file { "${certs::ssl_build_dir}/KATELLO-TRUSTED-SSL-CERT":

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -21,6 +21,7 @@ class certs::ca (
   String $ca_key_password = $certs::ca_key_password,
   Stdlib::Absolutepath $ca_key_password_file = $certs::ca_key_password_file,
 ) {
+  $default_ca_path = "${certs::ssl_build_dir}/${default_ca_name}.crt"
   $server_ca_path = "${certs::ssl_build_dir}/${server_ca_name}.crt"
 
   file { $ca_key_password_file:
@@ -57,7 +58,7 @@ class certs::ca (
     } else {
       file { $server_ca_path:
         ensure => file,
-        source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
+        source => $default_ca_path,
         owner  => 'root',
         group  => 'root',
         mode   => '0644',
@@ -74,7 +75,7 @@ class certs::ca (
   if $deploy {
     file { $certs::katello_default_ca_cert:
       ensure => file,
-      source => "${certs::ssl_build_dir}/${default_ca_name}.crt",
+      source => $default_ca_path,
       owner  => 'root',
       group  => 'root',
       mode   => '0644',


### PR DESCRIPTION
The resource always defined the same file, just with a different source. That source is either the provided `server_ca_cert` or the default CA.

It also introduces `$default_ca_path` to make it easier to see the same value is used in multiple places.