### PR TITLE
Fixes #38010 - Include keyalg in keytool for OpenJDK 17

### DIFF
--- a/lib/puppet_x/certs/provider/keystore.rb
+++ b/lib/puppet_x/certs/provider/keystore.rb
@@ -53,7 +53,8 @@ module PuppetX
               '-storepass:file', resource[:password_file],
               '-alias', temp_alias,
               '-dname', "CN=#{temp_alias}",
-              '-J-Dcom.redhat.fips=false'
+              '-J-Dcom.redhat.fips=false',
+              '-keyalg', 'RSA'
             )
           rescue Puppet::ExecutionFailure => e
             Puppet.err("Failed to generate new #{type} with temporary entry: #{e}")

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -37,7 +37,7 @@ describe 'certs' do
           }
         }
 
-        package { 'java-11-openjdk-headless':
+        package { 'java-17-openjdk-headless':
           ensure => installed,
         }
 
@@ -234,7 +234,7 @@ describe 'certs' do
         }
       }
 
-      package { 'java-11-openjdk-headless':
+      package { 'java-17-openjdk-headless':
         ensure => installed,
       }
 
@@ -275,7 +275,7 @@ describe 'certs' do
           path    => ['/bin', '/usr/bin'],
         }
       }
-      package { 'java-11-openjdk-headless':
+      package { 'java-17-openjdk-headless':
         ensure => installed,
       }
       include certs::candlepin

--- a/spec/acceptance/keystore_spec.rb
+++ b/spec/acceptance/keystore_spec.rb
@@ -7,7 +7,7 @@ describe 'certs' do
         <<-PUPPET
         $keystore_password_file = '/etc/pki/keystore_password-file'
 
-        package { 'java-11-openjdk-headless':
+        package { 'java-17-openjdk-headless':
           ensure => installed,
         }
 

--- a/spec/acceptance/truststore_spec.rb
+++ b/spec/acceptance/truststore_spec.rb
@@ -10,7 +10,7 @@ describe 'certs' do
         <<-PUPPET
         $truststore_password_file = '/etc/pki/truststore_password-file'
 
-        package { 'java-11-openjdk-headless':
+        package { 'java-17-openjdk-headless':
           ensure => installed,
         }
 
@@ -94,7 +94,7 @@ describe 'certs' do
           <<-PUPPET
           $truststore_password_file = '/etc/pki/truststore_password-file'
 
-          package { 'java-11-openjdk-headless':
+          package { 'java-17-openjdk-headless':
             ensure => installed,
           }
 
@@ -158,7 +158,7 @@ describe 'certs' do
           <<-PUPPET
           $truststore_password_file = '/etc/pki/truststore_password-file'
 
-          package { 'java-11-openjdk-headless':
+          package { 'java-17-openjdk-headless':
             ensure => installed,
           }
 


### PR DESCRIPTION
This is to the 18.0-stable branch which is used in Foreman 3.11.

(cherry picked from commit dc0f12e0e2737953780f40b857fe5920e18feb5c)