### PR TITLE
Only create password file when generate is true

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -23,14 +23,18 @@ class certs::ca (
   $default_ca_path = "${certs::ssl_build_dir}/${default_ca_name}.crt"
   $server_ca_path = "${certs::ssl_build_dir}/${server_ca_name}.crt"
 
-  file { $ca_key_password_file:
-    ensure    => file,
-    content   => $ca_key_password,
-    owner     => 'root',
-    group     => 'root',
-    mode      => '0400',
-    show_diff => false,
-  } ~>
+  if $generate {
+    file { $ca_key_password_file:
+      ensure    => file,
+      content   => $ca_key_password,
+      owner     => 'root',
+      group     => 'root',
+      mode      => '0400',
+      show_diff => false,
+      notify    => Ca[$default_ca_name],
+    }
+  }
+
   ca { $default_ca_name:
     ensure        => present,
     common_name   => $ca_common_name,

--- a/spec/acceptance/certs_tar_extract_spec.rb
+++ b/spec/acceptance/certs_tar_extract_spec.rb
@@ -153,4 +153,8 @@ describe 'certs with tar archive' do
       its(:keylength) { should be >= 2048 }
     end
   end
+
+  describe file('/root/ssl-build/katello-default-ca.pwd') do
+    it { should_not exist }
+  end
 end


### PR DESCRIPTION
This was, for example, causing a password file to get created on proxies that was not used by anything.