### PR TITLE
Drop references to the deployed CA key that is not deployed

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -15,7 +15,6 @@ class certs::ca (
   String $owner = $certs::user,
   String $group = $certs::group,
   Stdlib::Absolutepath $katello_server_ca_cert = $certs::katello_server_ca_cert,
-  Stdlib::Absolutepath $ca_key = $certs::ca_key,
   Stdlib::Absolutepath $ca_cert = $certs::ca_cert,
   Stdlib::Absolutepath $ca_cert_stripped = $certs::ca_cert_stripped,
   String $ca_key_password = $certs::ca_key_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,6 @@ class certs (
     }
   }
 
-  $ca_key = "${pki_dir}/private/${default_ca_name}.key"
   $ca_cert = "${pki_dir}/certs/${default_ca_name}.crt"
   $ca_cert_stripped = "${pki_dir}/certs/${default_ca_name}-stripped.crt"
   $ca_key_password = extlib::cache_data('foreman_cache_data', 'ca_key_password', extlib::random_password(24))


### PR DESCRIPTION
This only exists in the build directory and these references are unused.