### PR TITLE
Explicitly set deploy to false for foreman_proxy_content class

### DIFF
--- a/manifests/foreman_proxy_content.pp
+++ b/manifests/foreman_proxy_content.pp
@@ -23,9 +23,23 @@ class certs::foreman_proxy_content (
     fail('The hostname is the same as the provided hostname for the foreman-proxy')
   }
 
-  class { 'certs::puppet':              hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
-  class { 'certs::foreman_proxy':       hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
-  class { 'certs::apache':              hostname => $foreman_proxy_fqdn, cname => $foreman_proxy_cname }
+  class { 'certs::puppet':
+    deploy   => false,
+    hostname => $foreman_proxy_fqdn,
+    cname    => $foreman_proxy_cname,
+  }
+
+  class { 'certs::foreman_proxy':
+    deploy   => false,
+    hostname => $foreman_proxy_fqdn,
+    cname    => $foreman_proxy_cname,
+  }
+
+  class { 'certs::apache':
+    deploy   => false,
+    hostname => $foreman_proxy_fqdn,
+    cname    => $foreman_proxy_cname,
+  }
 
   certs::tar_create { $certs_tar:
     subscribe => Class['certs::puppet', 'certs::foreman_proxy', 'certs::apache'],


### PR DESCRIPTION
This class is intended to generate certificates and the wrap them in a tarball for distribution and not to ever deploy. This has always been used in context of foreman-installer where it relies upon this being set at the top level class level (https://github.com/theforeman/foreman-installer/blob/develop/katello_certs/config/foreman-proxy-certs-answers.yaml#L4) creating a dependency that can be loosened.