### PR TITLE
Remove cleanup of KATELLO-TRUSTED-SSL-CERT

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -53,10 +53,6 @@ class certs::ca (
       group  => 'root',
       mode   => '0644',
     }
-
-    file { "${certs::ssl_build_dir}/KATELLO-TRUSTED-SSL-CERT":
-      ensure  => absent,
-    }
   }
 
   if $deploy {


### PR DESCRIPTION
Refs 33130e2aa712657c746210f5419026c00ffb1cc2

Additional cleanup of files that were marked absent in a previous release and should be deployed by now.