### PR TITLE
Allow certs::foreman to be included at the top level of Kafo answers

### DIFF
--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -1,48 +1,49 @@
 # Handles Foreman certs configuration
 class certs::foreman (
-  Stdlib::Fqdn $hostname = $certs::node_fqdn,
-  Array[Stdlib::Fqdn] $cname = $certs::cname,
-  Boolean $generate = $certs::generate,
-  Boolean $regenerate = $certs::regenerate,
-  Boolean $deploy = $certs::deploy,
+  Optional[Stdlib::Fqdn] $hostname = undef,
+  Optional[Array[Stdlib::Fqdn]] $cname = undef,
+  Optional[Boolean] $generate = undef,
+  Optional[Boolean] $regenerate = undef,
+  Optional[Boolean] $deploy = undef,
   Stdlib::Absolutepath $client_cert = '/etc/foreman/client_cert.pem',
   Stdlib::Absolutepath $client_key = '/etc/foreman/client_key.pem',
   Stdlib::Absolutepath $ssl_ca_cert = '/etc/foreman/proxy_ca.pem',
-  String[2,2] $country = $certs::country,
-  String $state = $certs::state,
-  String $city = $certs::city,
+  Optional[String[2,2]] $country = undef,
+  Optional[String] $state = undef,
+  Optional[String] $city = undef,
   String $org = 'FOREMAN',
   String $org_unit = 'PUPPET',
-  String $expiration = $certs::expiration,
-  Stdlib::Absolutepath $ca_key_password_file = $certs::ca_key_password_file,
-  Stdlib::Absolutepath $server_ca = $certs::katello_server_ca_cert,
+  Optional[String] $expiration = undef,
   String $owner = 'root',
   String $group = 'foreman',
-) inherits certs {
-  $client_cert_name = "${hostname}-foreman-client"
-  $client_dn = "CN=${hostname}, OU=${org_unit}, O=${org}, ST=${state}, C=${country}"
+) {
+  include certs
+
+  $real_hostname = pick($hostname, $certs::node_fqdn)
+  $client_cert_name = "${real_hostname}-foreman-client"
+  $client_dn = "CN=${real_hostname}, OU=${org_unit}, O=${org}, ST=${state}, C=${country}"
 
   # cert for authentication of puppetmaster against foreman
   cert { $client_cert_name:
-    hostname      => $hostname,
-    cname         => $cname,
+    hostname      => $real_hostname,
+    cname         => pick($cname, $certs::cname),
     purpose       => 'client',
-    country       => $country,
-    state         => $state,
-    city          => $city,
+    country       => pick($country, $certs::country),
+    state         => pick($state, $certs::state),
+    city          => pick($city, $certs::city),
     org           => $org,
     org_unit      => $org_unit,
-    expiration    => $expiration,
+    expiration    => pick($expiration, $certs::expiration),
     ca            => $certs::default_ca,
-    generate      => $generate,
-    regenerate    => $regenerate,
-    password_file => $ca_key_password_file,
+    generate      => pick($generate, $certs::generate),
+    regenerate    => pick($regenerate, $certs::regenerate),
+    password_file => $certs::ca_key_password_file,
     build_dir     => $certs::ssl_build_dir,
   }
 
-  if $deploy {
+  if pick($deploy, $certs::deploy) {
     certs::keypair { $client_cert_name:
-      source_dir => "${certs::ssl_build_dir}/${hostname}",
+      source_dir => "${certs::ssl_build_dir}/${real_hostname}",
       key_file   => $client_key,
       key_owner  => $owner,
       key_group  => $group,
@@ -56,11 +57,11 @@ class certs::foreman (
 
     file { $ssl_ca_cert:
       ensure  => file,
-      source  => $server_ca,
+      source  => $certs::katello_server_ca_cert,
       owner   => 'root',
       group   => $group,
       mode    => '0440',
-      require => File[$server_ca],
+      require => File[$certs::katello_server_ca_cert],
     }
   }
 }

--- a/spec/acceptance/foreman_spec.rb
+++ b/spec/acceptance/foreman_spec.rb
@@ -4,6 +4,8 @@ describe 'certs::foreman' do
   fqdn = fact('fqdn')
 
   before(:all) do
+    on default, 'rm -rf /root/ssl-build /etc/pki/katello /etc/foreman'
+
     manifest = <<~MANIFEST
       file { '/etc/foreman':
         ensure => directory,


### PR DESCRIPTION
This is an idea for an approach that would allow the `certs::` classes to be included at the top level of the answers file in kafo/foreman-installer. This only tackles `certs::foreman` to start and is a draft. I developed this in case it gives us more flexiblity in evolving the installer as there are times we need the certificates from puppet-certs.

This would allow a certs generate command (https://github.com/theforeman/foreman-installer/pull/935) without the need for a dedicated [generate class](https://github.com/theforeman/puppet-certs/pull/449).