### PR TITLE
Fix assertion to do actual comparison

### DIFF
--- a/spec/support/acceptance/ca_bundle.rb
+++ b/spec/support/acceptance/ca_bundle.rb
@@ -24,7 +24,7 @@ else
         def has_cert?(file_path)
           target_cert = OpenSSL::X509::Certificate.new(@runner.get_file_content(file_path).stdout)
           content.any? do |actual_cert|
-            target_cert = actual_cert
+            target_cert == actual_cert
           end
         end
 


### PR DESCRIPTION
By using a single `=` the value is assigned, which is always true.

Fixes: 340c8ee5d9ba36d4b0bd4ddd1b9a629d3eed6256 ("Generate a ca-bundle of the default and server certificates")